### PR TITLE
Make do_encode and do_decode eligible for Tail-Call Optimization

### DIFF
--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -147,16 +147,16 @@ defmodule ABI.TypeDecoder do
       [{"awesome", true}]
   """
   def decode_raw(encoded_data, types) do
-    do_decode(types, encoded_data)
+    do_decode(types, encoded_data, [])
   end
 
-  @spec do_decode([ABI.FunctionSelector.type], binary()) :: [any()]
-  defp do_decode([], bin) when byte_size(bin) > 0, do: raise("Found extra binary data: #{inspect bin}")
-  defp do_decode([], _), do: []
-  defp do_decode([type|remaining_types], data) do
+  @spec do_decode([ABI.FunctionSelector.type], binary(), [any()]) :: [any()]
+  defp do_decode([], bin, _) when byte_size(bin) > 0, do: raise("Found extra binary data: #{inspect bin}")
+  defp do_decode([], _, acc), do: Enum.reverse(acc)
+  defp do_decode([type|remaining_types], data, acc) do
     {decoded, remaining_data} = decode_type(type, data)
 
-    [decoded | do_decode(remaining_types, remaining_data)]
+    do_decode(remaining_types, remaining_data, [decoded | acc])
   end
 
   @spec decode_type(ABI.FunctionSelector.type, binary()) :: {any(), binary()}

--- a/lib/abi/type_encoder.ex
+++ b/lib/abi/type_encoder.ex
@@ -115,7 +115,7 @@ defmodule ABI.TypeEncoder do
       "000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000007617765736f6d6500000000000000000000000000000000000000000000000000"
   """
   def encode_raw(data, types) do
-    do_encode(types, data)
+    do_encode(types, data, [])
   end
 
   @spec encode_method_id(%ABI.FunctionSelector{}) :: binary()
@@ -133,12 +133,12 @@ defmodule ABI.TypeEncoder do
     init
   end
 
-  @spec do_encode([ABI.FunctionSelector.type], [any()]) :: binary()
-  defp do_encode([], _), do: <<>>
-  defp do_encode([type|remaining_types], data) do
+  @spec do_encode([ABI.FunctionSelector.type], [any()], [binary()]) :: binary()
+  defp do_encode([], _, acc), do: :erlang.iolist_to_binary(Enum.reverse(acc))
+  defp do_encode([type|remaining_types], data, acc) do
     {encoded, remaining_data} = encode_type(type, data)
 
-    encoded <> do_encode(remaining_types, remaining_data)
+    do_encode(remaining_types, remaining_data, [encoded | acc])
   end
 
   @spec encode_type(ABI.FunctionSelector.type, [any()]) :: {binary(), [any()]}


### PR DESCRIPTION
Like with exthereum/evm#32, `ABI.TypeEncoder.do_encode/2` and `ABI.TypeDecoder.do_decode/2` are performing operations after the recursive self-call, and so can blow their stacks. This PR rephrases them into tail-call-with-accumulator style.

Bonus efficiency fix: instead of repeatedly joining binaries in `do_encode/2`, an `iolist()` is built and then baked into a binary at the end using `:erlang.iolist_to_binary/1`.

No visible behaviour changes. Tests pass.