### PR TITLE
Parse ABI spec documents

### DIFF
--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -8,6 +8,8 @@ defmodule ABI do
   @doc """
   Encodes the given data into the function signature or tuple signature.
 
+  In place of a signature, you can also pass one of the `ABI.FunctionSelector` structs returned from `parse_specification/1`.
+
   ## Examples
 
       iex> ABI.encode("baz(uint,address)", [50, <<1::160>> |> :binary.decode_unsigned])
@@ -24,17 +26,27 @@ defmodule ABI do
       iex> ABI.encode("(string)", [{"Ether Token"}])
       ...> |> Base.encode16(case: :lower)
       "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b457468657220546f6b656e000000000000000000000000000000000000000000"
+
+      iex> File.read!("priv/dog.abi.json")
+      ...> |> Poison.decode!
+      ...> |> ABI.parse_specification
+      ...> |> Enum.find(&(&1.function == "bark")) # bark(address,bool)
+      ...> |> ABI.encode([<<1::160>> |> :binary.decode_unsigned, true])
+      ...> |> Base.encode16(case: :lower)
+      "b85d0bd200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001"
   """
-  def encode(function_signature, data) do
-    ABI.TypeEncoder.encode(
-      data,
-      ABI.FunctionSelector.decode(function_signature)
-    )
+  def encode(function_signature, data) when is_binary(function_signature) do
+    encode(ABI.FunctionSelector.decode(function_signature), data)
+  end
+  def encode(%ABI.FunctionSelector{} = function_selector, data) do
+    ABI.TypeEncoder.encode(data, function_selector)
   end
 
   @doc """
   Decodes the given data based on the function or tuple
   signature.
+
+  In place of a signature, you can also pass one of the `ABI.FunctionSelector` structs returned from `parse_specification/1`.
 
   ## Examples
 
@@ -46,12 +58,19 @@ defmodule ABI do
 
       iex> ABI.decode("(string)", "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b457468657220546f6b656e000000000000000000000000000000000000000000" |> Base.decode16!(case: :lower))
       [{"Ether Token"}]
+
+      iex> File.read!("priv/dog.abi.json")
+      ...> |> Poison.decode!
+      ...> |> ABI.parse_specification
+      ...> |> Enum.find(&(&1.function == "bark")) # bark(address,bool)
+      ...> |> ABI.decode("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16!(case: :lower))
+      [<<1::160>>, true]
   """
-  def decode(function_signature, data) do
-    ABI.TypeDecoder.decode(
-      data,
-      ABI.FunctionSelector.decode(function_signature)
-    )
+  def decode(function_signature, data) when is_binary(function_signature) do
+    decode(ABI.FunctionSelector.decode(function_signature), data)
+  end
+  def decode(%ABI.FunctionSelector{} = function_selector, data) do
+    ABI.TypeDecoder.decode(data, function_selector)
   end
 
   @doc """

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -115,6 +115,35 @@ defmodule ABI.FunctionSelector do
     |> Enum.map(&decode_type/1)
   end
 
+  @doc false
+  def parse_specification_item(%{"type" => "function"} = item) do
+    %{
+      "name" => function_name,
+      "inputs" => named_inputs,
+      "outputs" => named_outputs
+    } = item
+
+    input_types = Enum.map(named_inputs, &parse_specification_type/1)
+    output_types = Enum.map(named_outputs, &parse_specification_type/1)
+
+    %ABI.FunctionSelector{
+      function: function_name,
+      types: input_types,
+      returns: List.first(output_types)
+    }
+  end
+  def parse_specification_item(%{"type" => "fallback"}) do
+    %ABI.FunctionSelector{
+      function: nil,
+      types: [],
+      returns: nil
+    }
+  end
+  def parse_specification_item(_), do: nil
+
+  defp parse_specification_type(%{"type" => type}), do: decode_type(type)
+
+  @doc false
   def decode_type(full_type) do
     cond do
       # Check for array type
@@ -140,6 +169,7 @@ defmodule ABI.FunctionSelector do
     end
   end
 
+  @doc false
   def decode_single_type("uint" <> size_str) do
     size = case size_str do
       "" -> 256 # default
@@ -203,6 +233,7 @@ defmodule ABI.FunctionSelector do
   end
   defp get_type(els), do: "Unsupported type: #{inspect els}"
 
+  @doc false
   @spec is_dynamic?(ABI.FunctionSelector.type) :: boolean
   def is_dynamic?(:bytes), do: true
   def is_dynamic?(:string), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule ABI.Mixfile do
   defp deps do
     [
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+      {:poison, "~> 3.1", only: [:dev, :test]},
       {:exth_crypto, "~> 0.1.4"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,5 @@
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "exth_crypto": {:hex, :exth_crypto, "0.1.4", "11f9084dfd70d4f9e96f2710a472f4e6b23044b97530c719550c2b0450ffeb61", [], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.3", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [], [], "hexpm"},
-  "libsecp256k1": {:hex, :libsecp256k1, "0.1.3", "57468b986af7c9633527875f71c7ca08bf4150b07b38a60d5bd48fba299ff6c1", [], [], "hexpm"}}
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.3", "57468b986af7c9633527875f71c7ca08bf4150b07b38a60d5bd48fba299ff6c1", [], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}

--- a/priv/dog.abi.json
+++ b/priv/dog.abi.json
@@ -1,0 +1,35 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "at",
+        "type": "address"
+      },
+      {
+        "name": "loudly",
+        "type": "bool"
+      }
+    ],
+    "name": "bark",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rollover",
+    "outputs": [
+      {
+        "name": "is_a_good_boy",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
This PR adds the ability to parse and use `.abi.json` files directly to encode and decode ABI types, by adding:

1. a function `ABI.parse_specification/1`, to parse an ABI specification document into a list of `ABI.FunctionSelector`s; and
2. extending `ABI.encode/2` and `ABI.decode/2` to also take `ABI.FunctionSelector`s directly.

No JSON library dependency is introduced; downstream users must instead first parse the `.abi.json` file themselves using their JSON library of choice, before passing the result to `ABI.parse_specification/1`.