### PR TITLE
Fix identifier parsing in BNF grammar

### DIFF
--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -48,6 +48,12 @@ defmodule ABI.FunctionSelector do
         types: []
       }
 
+      iex> ABI.FunctionSelector.decode("do_playDead3()")
+      %ABI.FunctionSelector{
+        function: "do_playDead3",
+        types: []
+      }
+
       iex> ABI.FunctionSelector.decode("pet(address[])")
       %ABI.FunctionSelector{
         function: "pet",

--- a/src/ethereum_abi_lexer.xrl
+++ b/src/ethereum_abi_lexer.xrl
@@ -1,15 +1,15 @@
 Definitions.
 
 INT        = [0-9]+
-LETTERS    = [a-z_]+
+LETTERS    = [a-zA-Z_]+
 WHITESPACE = [\s\t\n\r]
 TYPES      = uint|int|address|bool|fixed|uint|ufixed|bytes|function|string
 
 Rules.
 
-{TYPES}       : {token, {atom,       TokenLine, list_to_atom(TokenChars)}}.
-{INT}         : {token, {int,        TokenLine, list_to_integer(TokenChars)}}.
-{LETTERS}     : {token, {binary,     TokenLine, list_to_binary(TokenChars)}}.
+{TYPES}       : {token, {typename,   TokenLine, TokenChars}}.
+{INT}         : {token, {digits,     TokenLine, TokenChars}}.
+{LETTERS}     : {token, {letters,    TokenLine, TokenChars}}.
 \[            : {token, {'[',        TokenLine}}.
 \]            : {token, {']',        TokenLine}}.
 \(            : {token, {'(',        TokenLine}}.

--- a/src/ethereum_abi_parser.yrl
+++ b/src/ethereum_abi_parser.yrl
@@ -1,10 +1,10 @@
-Terminals '(' ')' '[' ']' ',' '->' int atom binary 'expecting selector' 'expecting type'.
-Nonterminals dispatch selector nontrivial_selector comma_delimited_types type_with_subscripts array_subscripts tuple array_subscript identifier type typespec.
+Terminals '(' ')' '[' ']' ',' '->' typename letters digits 'expecting selector' 'expecting type'.
+Nonterminals dispatch selector nontrivial_selector comma_delimited_types type_with_subscripts array_subscripts tuple array_subscript identifier  identifier_parts identifier_part type typespec.
 Rootsymbol dispatch.
 
 dispatch -> 'expecting type' type_with_subscripts : {type, '$2'}.
 dispatch -> 'expecting selector' selector : {selector, '$2'}.
-dispatch -> type_with_subscripts : {selector, #{function => nil, types => ['$1'], returns => nil}}.
+dispatch -> tuple : {selector, #{function => nil, types => ['$1'], returns => nil}}.
 dispatch -> nontrivial_selector : {selector, '$1'}.
 
 selector -> typespec : #{function => nil, types => '$1', returns => nil}.
@@ -23,8 +23,14 @@ tuple -> '(' comma_delimited_types ')' : {tuple, '$2'}.
 comma_delimited_types -> type_with_subscripts : ['$1'].
 comma_delimited_types -> type_with_subscripts ',' comma_delimited_types : ['$1' | '$3'].
 
-identifier -> atom : atom_to_list(v('$1')).
-identifier -> binary : v('$1').
+identifier -> identifier_parts : iolist_to_binary('$1').
+
+identifier_parts -> identifier_part : ['$1'].
+identifier_parts -> identifier_part identifier_parts : ['$1' | '$2'].
+
+identifier_part -> typename : v('$1').
+identifier_part -> letters : v('$1').
+identifier_part -> digits : v('$1').
 
 type_with_subscripts -> type : '$1'.
 type_with_subscripts -> type array_subscripts : with_subscripts('$1', '$2').
@@ -33,14 +39,14 @@ array_subscripts -> array_subscript : ['$1'].
 array_subscripts -> array_subscript array_subscripts : ['$1' | '$2'].
 
 array_subscript -> '[' ']' : variable.
-array_subscript -> '[' int ']' : v('$2').
+array_subscript -> '[' digits ']' : list_to_integer(v('$2')).
 
-type -> atom :
-  plain_type(v('$1')).
-type -> atom int :
-  juxt_type(v('$1'), v('$2')).
-type -> atom int identifier int :
-  double_juxt_type(v('$1'), v('$4'), v('$2'), v('$3')).
+type -> typename :
+  plain_type(list_to_atom(v('$1'))).
+type -> typename digits :
+  juxt_type(list_to_atom(v('$1')), list_to_integer(v('$2'))).
+type -> typename digits letters digits :
+  double_juxt_type(list_to_atom(v('$1')), v('$3'), list_to_integer(v('$2')), list_to_integer(v('$4'))).
 type -> tuple : '$1'.
 
 
@@ -68,5 +74,5 @@ juxt_type(int, M) when M > 0, M =< 256, (M rem 8) =:= 0 -> {int, M};
 juxt_type(uint, M) when M > 0, M =< 256, (M rem 8) =:= 0 -> {uint, M};
 juxt_type(bytes, M) when M > 0, M =< 32 -> {bytes, M}.
 
-double_juxt_type(fixed, "x", M, N) when M >= 0, M =< 256, (M rem 8) =:= 0, N > 0, N =< 80 -> {fixed, M, N};
-double_juxt_type(ufixed, "x", M, N) when M >= 0, M =< 256, (M rem 8) =:= 0, N > 0, N =< 80 -> {ufixed, M, N}.
+double_juxt_type(fixed, 'x', M, N) when M >= 0, M =< 256, (M rem 8) =:= 0, N > 0, N =< 80 -> {fixed, M, N};
+double_juxt_type(ufixed, 'x', M, N) when M >= 0, M =< 256, (M rem 8) =:= 0, N > 0, N =< 80 -> {ufixed, M, N}.


### PR DESCRIPTION
Sorry for another PR so soon; I just realized that the yecc grammar I had provided in my previous PR doesn't parse function signatures with function names like `fooBar()` or `foo_bar()` or `foo_uint256()` (or `B()` or `3()` or `uint256()`, which are also all—surprisingly—syntactically valid per spec).

This PR fixes that (and adds a doctest to assert that such a function signature decodes successfully.)

Fixing this problem, though, uncovers a second problem: the grammar as I wrote it contains an inherent parsing conflict (e.g. the plain string `uint256` is—without the context of items not yet on the parser's stack—either a `type` or an `identifier`.) This is only a problem when `ABI.Parser.parse!/2` is called without a type expectation (i.e. the form used for `ABI.encode/1` and `ABI.decode/1`), causing it to try to consume either a `type` or a `selector`.

I resolved this second problem by changing out the `type` clause for a `tuple` clause in the parser's implicit entrypoint. This also, conveniently, more tightly bounds possible outputs to the expectations of `ABI.encode/1` and `ABI.decode/1`. General `type` parsing is still available by explicitly passing `as: :type` to `parse!/2`, as done in `ABI.FunctionSelector.decode_type/1`.