### PR TITLE
Fix method ids, and bump version to 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.11
+* Add support for method ID calculation of all standard types
 # 0.1.10
 * Fix parsing of function names containing uppercase letters/digits/underscores
 * Add support for `bytes<M>`

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -194,7 +194,7 @@ defmodule ABI.FunctionSelector do
 
     "(#{encoded_types})"
   end
-  defp get_type(els), do: "Unsupported type: #{inspect els}"
+  defp get_type(els), do: raise "Unsupported type: #{inspect els}"
 
   @doc false
   @spec is_dynamic?(ABI.FunctionSelector.type) :: boolean

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -181,19 +181,27 @@ defmodule ABI.FunctionSelector do
     end
   end
 
+  defp get_type(nil), do: nil
+  defp get_type({:int, size}), do: "int#{size}"
   defp get_type({:uint, size}), do: "uint#{size}"
-  defp get_type(:bool), do: "bool"
-  defp get_type(:string), do: "string"
   defp get_type(:address), do: "address"
-  defp get_type({:array, type}), do: "#{get_type(type)}[]"
-  defp get_type({:array, type, element_count}), do: "#{get_type(type)}[#{element_count}]"
-  defp get_type({:tuple, types}) do
-    encoded_types = types
-    |> Enum.map(&get_type/1)
-    |> Enum.join(",")
+  defp get_type(:bool), do: "bool"
+  defp get_type({:fixed, element_count, precision}), do: "fixed#{element_count}x#{precision}"
+  defp get_type({:ufixed, element_count, precision}), do: "ufixed#{element_count}x#{precision}"
+  defp get_type({:bytes, size}), do: "bytes#{size}"
+  defp get_type(:function), do: "function"
 
-    "(#{encoded_types})"
+  defp get_type({:array, type, element_count}), do: "#{get_type(type)}[#{element_count}]"
+
+  defp get_type(:bytes), do: "bytes"
+  defp get_type(:string), do: "string"
+  defp get_type({:array, type}), do: "#{get_type(type)}[]"
+
+  defp get_type({:tuple, types}) do
+    encoded_types = Enum.map(types, &get_type/1)
+    "(#{Enum.join(encoded_types, ",")})"
   end
+
   defp get_type(els), do: raise "Unsupported type: #{inspect els}"
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ABI.Mixfile do
 
   def project do
     [app: :abi,
-     version: "0.1.10",
+     version: "0.1.11",
       elixir: "~> 1.4",
       description: "Ethereum's ABI Interface",
       package: [


### PR DESCRIPTION
Currently, because of [this line](https://github.com/exthereum/abi/blob/02d1f3e5af4006959d01d8f8eac4ec137e63b68f/lib/abi/function_selector.ex#L197), attempting to calculate the method ID for a function-signature containing an type unimplemented in `ABI.FunctionSelector.get_type/1` fails to raise an exception, and instead silently returns a corrupted method ID.

This PR fixes the problematic line to actually `raise`, but goes further by implementing proper `get_type/1` support for every standard ABI type. The problematic line should never be reachable now.