### PR TITLE
Fix decoding of tuples and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.12
+* Fix `string` decoding to truncate on encountering NUL
+* Fix some edge-cases in `tuple` encoding/decoding
 # 0.1.11
 * Add support for method ID calculation of all standard types
 # 0.1.10

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -215,8 +215,8 @@ defmodule ABI.FunctionSelector do
   def is_dynamic?(:bytes), do: true
   def is_dynamic?(:string), do: true
   def is_dynamic?({:array, _type}), do: true
-  def is_dynamic?({:array, _type, _length}), do: true
-  def is_dynamic?({:tuple, _types}), do: true
+  def is_dynamic?({:array, type, len}) when len > 0, do: is_dynamic?(type)
+  def is_dynamic?({:tuple, types}), do: Enum.any?(types, &is_dynamic?/1)
   def is_dynamic?(_), do: false
 
 end

--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -180,7 +180,8 @@ defmodule ABI.TypeDecoder do
 
   defp decode_type(:string, data) do
     {string_size_in_bytes, rest} = decode_uint(data, 256)
-    decode_bytes(rest, string_size_in_bytes, :right)
+    {raw_bytes, rest} = decode_bytes(rest, string_size_in_bytes, :right)
+    {nul_terminate_string(raw_bytes), rest}
   end
 
   defp decode_type(:bytes, data) do
@@ -268,4 +269,9 @@ defmodule ABI.TypeDecoder do
     end
   end
 
+  defp nul_terminate_string(raw_string) do
+    raw_string = :erlang.iolist_to_binary(raw_string)
+    [pre_nul_part | _] = :binary.split(raw_string, <<0>>)
+    pre_nul_part
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ABI.Mixfile do
 
   def project do
     [app: :abi,
-     version: "0.1.11",
+     version: "0.1.12",
       elixir: "~> 1.4",
       description: "Ethereum's ABI Interface",
       package: [


### PR DESCRIPTION
`ABI.FunctionSelector.is_dynamic?/1` didn't quite match up with the conditions outlined in [the spec](https://solidity.readthedocs.io/en/develop/abi-spec.html#formal-specification-of-the-encoding). This could cause improper encodings (that contracts can't read) and decoding errors, when types that were encoded as dynamic actually weren't. This PR corrects this.

---

`ABI.TypeDecoder.decode_type(:string, data)` could (and, in my testing, sometimes does) return 'strings' that look like `"foo" <> <<0, 0, 0, 0, 0>>`—probably because someone manually did some padding in a client, or wrote some bad logic into a contract. Strings containing a `NUL` octet aren't actually `string()`s from Elixir's perspective; Elixir will complain when you attempt to put them through most `String` functions. Given that anyone who wanted a binary like the above to survive a round trip unscathed would have used `:bytes` in their function signature instead, it would make sense to ensure that `:string` always decodes to a valid `string()`—in this case by truncating at the first `NUL` encountered, like in C. This PR adds a small function to do this `NUL`-truncation, and makes `decode_type(:string, data)` pass its return-value through it.

Advantages:
* no extra work is required to normalize strings returned by `ABI.decode/2` in order to actually use them as strings (e.g. inserting them into a `TEXT`-typed column in Postgres, where `NUL`s are not accepted)
* allows for matching against decoded `:string` outputs of arbitrary length that are entirely `NUL` internally, by just comparing them for equality with `""` (I needed to do this just today when programmatically interacting with the Parity token registry)

Disadvantages:
* `ABI.encode(..., sel_foo) |> ABI.decode(sel_foo)` is no longer bijective if your input is a mismatch for the `:string` type. This is problematic if `ABI.decode/2` is being used to decode input data for debugging encoding.

Thoughts?