### PR TITLE
CircleCI Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/abi
+    docker:
+      - image: elixir:latest
+    steps:
+      - checkout
+
+      - restore_cache:
+         keys:
+           - v1-dependency-cache-{{ arch }}-{{ checksum "mix.lock" }}
+           - v1-dependency-cache-{{ arch }}
+           - v1-dependency-cache
+
+      - run: mix local.hex --force
+      - run: mix deps.get
+
+      - run: mix credo
+      - run: mix format --check-formatted
+
+      - run: mix test
+
+      - save_cache:
+          key: v1-dependency-cache-{{ arch }}-{{ checksum "mix.lock" }}
+          paths:
+            - _build
+            - deps
+            - ~/.mix
+
+      - restore_cache:
+          keys:
+            - v1-plt-cache-{{ arch }}-{{ checksum "mix.lock" }}
+            - v1-plt-cache-{{ arch }}
+            - v1-plt-cache
+
+      - run: mix dialyzer --plt
+
+      - save_cache:
+          key: v1-plt-cache-{{ arch }}-{{ checksum "mix.lock" }}
+          paths:
+            - _build
+            - ~/.mix
+
+      - run: mix dialyzer --halt-exit-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: elixir:latest
     steps:
+      - run: apt-get update; apt-get -y install libtool autoconf libgmp3-dev
       - checkout
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
            - v1-dependency-cache
 
       - run: mix local.hex --force
+      - run: mix local.rebar --force
       - run: mix deps.get
 
       - run: mix credo

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,160 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any exec using `mix credo -C <name>`. If no exec name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        #
+        ## Consistency Checks
+        #
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.ParameterPatternMatching},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses, false},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage, priority: :low},
+        # For some checks, you can also set other parameters
+        #
+        # If you don't want the `setup` and `test` macro calls in ExUnit tests
+        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+        #
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagFIXME},
+
+        #
+        ## Readability Checks
+        #
+        {Credo.Check.Readability.AliasOrder},
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+        {Credo.Check.Readability.ParenthesesInCondition},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.StringSigils},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Readability.Semicolons},
+        {Credo.Check.Readability.SpaceAfterCommas},
+
+        #
+        ## Refactoring Opportunities
+        #
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.LongQuoteBlocks},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.PipeChainStart, false}, #,
+        # excluded_argument_types: [:atom, :binary, :fn, :keyword], excluded_functions: []},
+        {Credo.Check.Refactor.UnlessWithElse},
+
+        #
+        ## Warnings
+        #
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.LazyLogging},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+        {Credo.Check.Warning.RaiseInsideRescue},
+
+        #
+        # Controversial and experimental checks (opt-in, just remove `, false`)
+        #
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+
+        #
+        # Deprecated checks (these will be deleted after a grace period)
+        #
+        {Credo.Check.Readability.Specs, false}
+
+        #
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/.credo.exs
+++ b/.credo.exs
@@ -76,7 +76,7 @@
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
         #
-        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagTODO, exit_status: 0},
         {Credo.Check.Design.TagFIXME},
 
         #

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ABI
+# ABI [![CircleCI](https://circleci.com/gh/exthereum/abi.svg?style=svg)](https://circleci.com/gh/exthereum/abi)
 
 The [Application Binary Interface](https://solidity.readthedocs.io/en/develop/abi-spec.html) (ABI) of Solidity describes how to transform binary data to types which the Solidity programming language understands. For instance, if we want to call a function `bark(uint32,bool)` on a Solidity-created contract `contract Dog`, what `data` parameter do we pass into our Ethereum transaction? This project allows us to encode such function calls.
 

--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -42,6 +42,7 @@ defmodule ABI do
   def encode(function_signature, data) when is_binary(function_signature) do
     encode(ABI.Parser.parse!(function_signature), data)
   end
+
   def encode(%ABI.FunctionSelector{} = function_selector, data) do
     ABI.TypeEncoder.encode(data, function_selector)
   end
@@ -73,6 +74,7 @@ defmodule ABI do
   def decode(function_signature, data) when is_binary(function_signature) do
     decode(ABI.Parser.parse!(function_signature), data)
   end
+
   def decode(%ABI.FunctionSelector{} = function_selector, data) do
     ABI.TypeDecoder.decode(data, function_selector)
   end
@@ -132,6 +134,6 @@ defmodule ABI do
   def parse_specification(doc) do
     doc
     |> Enum.map(&ABI.FunctionSelector.parse_specification_item/1)
-    |> Enum.filter(&(&1))
+    |> Enum.filter(& &1)
   end
 end

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -7,20 +7,20 @@ defmodule ABI.FunctionSelector do
   require Integer
 
   @type type ::
-    {:uint, integer()} |
-    :bool |
-    :bytes |
-    :string |
-    :address |
-    {:array, type} |
-    {:array, type, non_neg_integer} |
-    {:tuple, [type]}
+          {:uint, integer()}
+          | :bool
+          | :bytes
+          | :string
+          | :address
+          | {:array, type}
+          | {:array, type, non_neg_integer}
+          | {:tuple, [type]}
 
   @type t :: %__MODULE__{
-    function: String.t,
-    types: [type],
-    returns: type
-  }
+          function: String.t(),
+          types: [type],
+          returns: type
+        }
 
   defstruct [:function, :types, :returns]
 
@@ -129,6 +129,7 @@ defmodule ABI.FunctionSelector do
       returns: List.first(output_types)
     }
   end
+
   def parse_specification_item(%{"type" => "fallback"}) do
     %ABI.FunctionSelector{
       function: nil,
@@ -136,6 +137,7 @@ defmodule ABI.FunctionSelector do
       returns: nil
     }
   end
+
   def parse_specification_item(_), do: nil
 
   defp parse_specification_type(%{"type" => type}), do: decode_type(type)
@@ -208,15 +210,14 @@ defmodule ABI.FunctionSelector do
     "(#{Enum.join(encoded_types, ",")})"
   end
 
-  defp get_type(els), do: raise "Unsupported type: #{inspect els}"
+  defp get_type(els), do: raise("Unsupported type: #{inspect(els)}")
 
   @doc false
-  @spec is_dynamic?(ABI.FunctionSelector.type) :: boolean
+  @spec is_dynamic?(ABI.FunctionSelector.type()) :: boolean
   def is_dynamic?(:bytes), do: true
   def is_dynamic?(:string), do: true
   def is_dynamic?({:array, _type}), do: true
   def is_dynamic?({:array, type, len}) when len > 0, do: is_dynamic?(type)
   def is_dynamic?({:tuple, types}), do: Enum.any?(types, &is_dynamic?/1)
   def is_dynamic?(_), do: false
-
 end

--- a/lib/abi/parser.ex
+++ b/lib/abi/parser.ex
@@ -3,13 +3,14 @@ defmodule ABI.Parser do
 
   @doc false
   def parse!(str, opts \\ []) do
-    {:ok, tokens, _} = str |> String.to_charlist |> :ethereum_abi_lexer.string
+    {:ok, tokens, _} = str |> String.to_charlist() |> :ethereum_abi_lexer.string()
 
-    tokens = case opts[:as] do
-      nil -> tokens
-      :type -> [{:"expecting type", 1} | tokens]
-      :selector -> [{:"expecting selector", 1} | tokens]
-    end
+    tokens =
+      case opts[:as] do
+        nil -> tokens
+        :type -> [{:"expecting type", 1} | tokens]
+        :selector -> [{:"expecting selector", 1} | tokens]
+      end
 
     {:ok, ast} = :ethereum_abi_parser.parse(tokens)
 

--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -151,16 +151,19 @@ defmodule ABI.TypeDecoder do
     do_decode(types, encoded_data, [])
   end
 
-  @spec do_decode([ABI.FunctionSelector.type], binary(), [any()]) :: [any()]
-  defp do_decode([], bin, _) when byte_size(bin) > 0, do: raise("Found extra binary data: #{inspect bin}")
+  @spec do_decode([ABI.FunctionSelector.type()], binary(), [any()]) :: [any()]
+  defp do_decode([], bin, _) when byte_size(bin) > 0,
+    do: raise("Found extra binary data: #{inspect(bin)}")
+
   defp do_decode([], _, acc), do: Enum.reverse(acc)
-  defp do_decode([type|remaining_types], data, acc) do
+
+  defp do_decode([type | remaining_types], data, acc) do
     {decoded, remaining_data} = decode_type(type, data)
 
     do_decode(remaining_types, remaining_data, [decoded | acc])
   end
 
-  @spec decode_type(ABI.FunctionSelector.type, binary()) :: {any(), binary()}
+  @spec decode_type(ABI.FunctionSelector.type(), binary()) :: {any(), binary()}
   defp decode_type({:uint, size_in_bits}, data) do
     decode_uint(data, size_in_bits)
   end
@@ -170,10 +173,11 @@ defmodule ABI.TypeDecoder do
   defp decode_type(:bool, data) do
     {encoded_value, rest} = decode_uint(data, 8)
 
-    value = case encoded_value do
-      1 -> true
-      0 -> false
-    end
+    value =
+      case encoded_value do
+        1 -> true
+        0 -> false
+      end
 
     {value, rest}
   end
@@ -190,6 +194,7 @@ defmodule ABI.TypeDecoder do
   end
 
   defp decode_type({:bytes, 0}, data), do: {<<>>, data}
+
   defp decode_type({:bytes, size}, data) when size > 0 and size <= 32 do
     decode_bytes(data, size, :right)
   end
@@ -200,45 +205,49 @@ defmodule ABI.TypeDecoder do
   end
 
   defp decode_type({:array, _type, 0}, data), do: {[], data}
+
   defp decode_type({:array, type, element_count}, data) do
     repeated_type = Enum.map(1..element_count, fn _ -> type end)
 
     {tuple, rest} = decode_type({:tuple, repeated_type}, data)
 
-    {tuple |> Tuple.to_list, rest}
+    {tuple |> Tuple.to_list(), rest}
   end
 
   defp decode_type({:tuple, types}, starting_data) do
     # First pass, decode static types
-    {elements, rest} = Enum.reduce(types, {[], starting_data}, fn type, {elements, data} ->
-      if ABI.FunctionSelector.is_dynamic?(type) do
-        {tail_position, rest} = decode_type({:uint, 256}, data)
+    {elements, rest} =
+      Enum.reduce(types, {[], starting_data}, fn type, {elements, data} ->
+        if ABI.FunctionSelector.is_dynamic?(type) do
+          {tail_position, rest} = decode_type({:uint, 256}, data)
 
-        {[{:dynamic, type, tail_position}|elements], rest}
-      else
-        {el, rest} = decode_type(type, data)
-
-        {[el|elements], rest}
-      end
-    end)
-
-    # Second pass, decode dynamic types
-    {elements, rest} = Enum.reduce(elements |> Enum.reverse, {[], rest}, fn el, {elements, data} ->
-      case el do
-        {:dynamic, type, _tail_position} ->
+          {[{:dynamic, type, tail_position} | elements], rest}
+        else
           {el, rest} = decode_type(type, data)
 
-          {[el|elements], rest}
-        _ ->
-          {[el|elements], data}
-      end
-    end)
+          {[el | elements], rest}
+        end
+      end)
 
-    {elements |> Enum.reverse |> List.to_tuple, rest}
+    # Second pass, decode dynamic types
+    {elements, rest} =
+      Enum.reduce(elements |> Enum.reverse(), {[], rest}, fn el, {elements, data} ->
+        case el do
+          {:dynamic, type, _tail_position} ->
+            {el, rest} = decode_type(type, data)
+
+            {[el | elements], rest}
+
+          _ ->
+            {[el | elements], data}
+        end
+      end)
+
+    {elements |> Enum.reverse() |> List.to_tuple(), rest}
   end
 
   defp decode_type(els, _) do
-    raise "Unsupported decoding type: #{inspect els}"
+    raise "Unsupported decoding type: #{inspect(els)}"
   end
 
   @spec decode_uint(binary(), integer()) :: {integer(), binary()}
@@ -254,16 +263,21 @@ defmodule ABI.TypeDecoder do
   @spec decode_bytes(binary(), integer(), atom()) :: {binary(), binary()}
   def decode_bytes(data, size_in_bytes, padding_direction) do
     # TODO: Create `unright_pad` repo, err, add to `ExthCrypto.Math`
-    total_size_in_bytes = size_in_bytes + ExthCrypto.Math.mod( 32 - ExthCrypto.Math.mod(size_in_bytes, 32), 32)
+    total_size_in_bytes =
+      size_in_bytes + ExthCrypto.Math.mod(32 - ExthCrypto.Math.mod(size_in_bytes, 32), 32)
+
     padding_size_in_bytes = total_size_in_bytes - size_in_bytes
 
     case padding_direction do
       :left ->
-        <<_padding::binary-size(padding_size_in_bytes), value::binary-size(size_in_bytes), rest::binary()>> = data
+        <<_padding::binary-size(padding_size_in_bytes), value::binary-size(size_in_bytes),
+          rest::binary()>> = data
 
         {value, rest}
+
       :right ->
-        <<value::binary-size(size_in_bytes), _padding::binary-size(padding_size_in_bytes), rest::binary()>> = data
+        <<value::binary-size(size_in_bytes), _padding::binary-size(padding_size_in_bytes),
+          rest::binary()>> = data
 
         {value, rest}
     end

--- a/lib/abi/type_encoder.ex
+++ b/lib/abi/type_encoder.ex
@@ -202,7 +202,7 @@ defmodule ABI.TypeEncoder do
     encode_type({:tuple, repeated_type}, [data |> List.to_tuple | rest])
   end
 
-  defp encode_type({:array, type}, [data|_rest]=all_data) do
+  defp encode_type({:array, type}, [data|_rest] = all_data) do
     element_count = Enum.count(data)
 
     encoded_uint = encode_uint(element_count, 256)

--- a/lib/abi/type_encoder.ex
+++ b/lib/abi/type_encoder.ex
@@ -98,8 +98,7 @@ defmodule ABI.TypeEncoder do
       "000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000001"
   """
   def encode(data, function_selector) do
-    encode_method_id(function_selector) <>
-    encode_raw(data, function_selector.types)
+    encode_method_id(function_selector) <> encode_raw(data, function_selector.types)
   end
 
   @doc """
@@ -120,11 +119,13 @@ defmodule ABI.TypeEncoder do
 
   @spec encode_method_id(%ABI.FunctionSelector{}) :: binary()
   defp encode_method_id(%ABI.FunctionSelector{function: nil}), do: ""
+
   defp encode_method_id(function_selector) do
     # Encode selector e.g. "baz(uint32,bool)" and take keccak
-    kec = function_selector
-    |> ABI.FunctionSelector.encode()
-    |> ExthCrypto.Hash.Keccak.kec()
+    kec =
+      function_selector
+      |> ABI.FunctionSelector.encode()
+      |> ExthCrypto.Hash.Keccak.kec()
 
     # Take first four bytes
     <<init::binary-size(4), _rest::binary>> = kec
@@ -133,65 +134,74 @@ defmodule ABI.TypeEncoder do
     init
   end
 
-  @spec do_encode([ABI.FunctionSelector.type], [any()], [binary()]) :: binary()
+  @spec do_encode([ABI.FunctionSelector.type()], [any()], [binary()]) :: binary()
   defp do_encode([], _, acc), do: :erlang.iolist_to_binary(Enum.reverse(acc))
-  defp do_encode([type|remaining_types], data, acc) do
+
+  defp do_encode([type | remaining_types], data, acc) do
     {encoded, remaining_data} = encode_type(type, data)
 
     do_encode(remaining_types, remaining_data, [encoded | acc])
   end
 
-  @spec encode_type(ABI.FunctionSelector.type, [any()]) :: {binary(), [any()]}
-  defp encode_type({:uint, size}, [data|rest]) do
+  @spec encode_type(ABI.FunctionSelector.type(), [any()]) :: {binary(), [any()]}
+  defp encode_type({:uint, size}, [data | rest]) do
     {encode_uint(data, size), rest}
   end
 
   defp encode_type(:address, data), do: encode_type({:uint, 160}, data)
 
-  defp encode_type(:bool, [data|rest]) do
-    value = case data do
-      true -> encode_uint(1, 8)
-      false -> encode_uint(0, 8)
-      _ -> raise "Invalid data for bool: #{data}"
-    end
+  defp encode_type(:bool, [data | rest]) do
+    value =
+      case data do
+        true -> encode_uint(1, 8)
+        false -> encode_uint(0, 8)
+        _ -> raise "Invalid data for bool: #{data}"
+      end
 
     {value, rest}
   end
 
-  defp encode_type(:string, [data|rest]) do
+  defp encode_type(:string, [data | rest]) do
     {encode_uint(byte_size(data), 256) <> encode_bytes(data), rest}
   end
 
-  defp encode_type(:bytes, [data|rest]) do
+  defp encode_type(:bytes, [data | rest]) do
     {encode_uint(byte_size(data), 256) <> encode_bytes(data), rest}
   end
 
-  defp encode_type({:bytes, size}, [data|rest]) when is_binary(data) and byte_size(data) <= size do
+  defp encode_type({:bytes, size}, [data | rest])
+       when is_binary(data) and byte_size(data) <= size do
     {encode_bytes(data), rest}
   end
-  defp encode_type({:bytes, size}, [data|_]) when is_binary(data) do
+
+  defp encode_type({:bytes, size}, [data | _]) when is_binary(data) do
     raise "size mismatch for bytes#{size}: #{inspect(data)}"
   end
-  defp encode_type({:bytes, size}, [data|_]) do
+
+  defp encode_type({:bytes, size}, [data | _]) do
     raise "wrong datatype for bytes#{size}: #{inspect(data)}"
   end
 
-  defp encode_type({:tuple, types}, [data|rest]) do
+  defp encode_type({:tuple, types}, [data | rest]) do
     # all head items are 32 bytes in length and there will be exactly
     # `count(types)` of them, so the tail starts at `32 * count(types)`.
-    tail_start = ( types |> Enum.count ) * 32
+    tail_start = (types |> Enum.count()) * 32
 
-    {head, tail, [], _} = Enum.reduce(types, {<<>>, <<>>, data |> Tuple.to_list, tail_start}, fn type, {head, tail, data, tail_position} ->
-      {el, rest} = encode_type(type, data)
+    {head, tail, [], _} =
+      Enum.reduce(types, {<<>>, <<>>, data |> Tuple.to_list(), tail_start}, fn type,
+                                                                               {head, tail, data,
+                                                                                tail_position} ->
+        {el, rest} = encode_type(type, data)
 
-      if ABI.FunctionSelector.is_dynamic?(type) do
-        # If we're a dynamic type, just encoded the length to head and the element to body
-        {head <> encode_uint(tail_position, 256), tail <> el, rest, tail_position + byte_size(el)}
-      else
-        # If we're a static type, simply encode the el to the head
-        {head <> el, tail, rest, tail_position}
-      end
-    end)
+        if ABI.FunctionSelector.is_dynamic?(type) do
+          # If we're a dynamic type, just encoded the length to head and the element to body
+          {head <> encode_uint(tail_position, 256), tail <> el, rest,
+           tail_position + byte_size(el)}
+        else
+          # If we're a static type, simply encode the el to the head
+          {head <> el, tail, rest, tail_position}
+        end
+      end)
 
     {head <> tail, rest}
   end
@@ -199,10 +209,10 @@ defmodule ABI.TypeEncoder do
   defp encode_type({:array, type, element_count}, [data | rest]) do
     repeated_type = Enum.map(1..element_count, fn _ -> type end)
 
-    encode_type({:tuple, repeated_type}, [data |> List.to_tuple | rest])
+    encode_type({:tuple, repeated_type}, [data |> List.to_tuple() | rest])
   end
 
-  defp encode_type({:array, type}, [data|_rest] = all_data) do
+  defp encode_type({:array, type}, [data | _rest] = all_data) do
     element_count = Enum.count(data)
 
     encoded_uint = encode_uint(element_count, 256)
@@ -212,7 +222,7 @@ defmodule ABI.TypeEncoder do
   end
 
   defp encode_type(els, _) do
-    raise "Unsupported encoding type: #{inspect els}"
+    raise "Unsupported encoding type: #{inspect(els)}"
   end
 
   def encode_bytes(bytes) do
@@ -222,18 +232,24 @@ defmodule ABI.TypeEncoder do
   # Note, we'll accept a binary or an integer here, so long as the
   # binary is not longer than our allowed data size
   defp encode_uint(data, size_in_bits) when rem(size_in_bits, 8) == 0 do
-    size_in_bytes = ( size_in_bits / 8 ) |> round
+    size_in_bytes = (size_in_bits / 8) |> round
     bin = maybe_encode_unsigned(data)
 
-    if byte_size(bin) > size_in_bytes, do: raise "Data overflow encoding uint, data `#{data}` cannot fit in #{size_in_bytes * 8} bits"
+    if byte_size(bin) > size_in_bytes,
+      do:
+        raise(
+          "Data overflow encoding uint, data `#{data}` cannot fit in #{size_in_bytes * 8} bits"
+        )
 
     bin |> pad(size_in_bytes, :left)
   end
 
   defp pad(bin, size_in_bytes, direction) do
     # TODO: Create `left_pad` repo, err, add to `ExthCrypto.Math`
-    total_size = size_in_bytes + ExthCrypto.Math.mod( 32 - ExthCrypto.Math.mod(size_in_bytes, 32), 32 )
-    padding_size_bits = ( total_size - byte_size(bin) ) * 8
+    total_size =
+      size_in_bytes + ExthCrypto.Math.mod(32 - ExthCrypto.Math.mod(size_in_bytes, 32), 32)
+
+    padding_size_bits = (total_size - byte_size(bin)) * 8
     padding = <<0::size(padding_size_bits)>>
 
     case direction do
@@ -245,5 +261,4 @@ defmodule ABI.TypeEncoder do
   @spec maybe_encode_unsigned(binary() | integer()) :: binary()
   defp maybe_encode_unsigned(bin) when is_binary(bin), do: bin
   defp maybe_encode_unsigned(int) when is_integer(int), do: :binary.encode_unsigned(int)
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule ABI.Mixfile do
     [
       {:credo, "~>  0.9.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+        {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
       {:poison, "~> 3.1", only: [:dev, :test]},
       {:exth_crypto, "~> 0.1.4"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule ABI.Mixfile do
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
       {:poison, "~> 3.1", only: [:dev, :test]},
-      {:exth_crypto, "~> 0.1.5"}
+      {:exth_crypto, "~> 0.1.6"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,8 +2,9 @@ defmodule ABI.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :abi,
-     version: "0.1.12",
+    [
+      app: :abi,
+      version: "0.1.12",
       elixir: "~> 1.4",
       description: "Ethereum's ABI Interface",
       package: [
@@ -11,9 +12,10 @@ defmodule ABI.Mixfile do
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/exthereum/abi"}
       ],
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
-      deps: deps()]
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Run "mix help compile.app" to learn about applications.

--- a/mix.exs
+++ b/mix.exs
@@ -30,9 +30,9 @@ defmodule ABI.Mixfile do
     [
       {:credo, "~>  0.9.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
-        {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
       {:poison, "~> 3.1", only: [:dev, :test]},
-      {:exth_crypto, "~> 0.1.4"}
+      {:exth_crypto, "~> 0.1.5"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule ABI.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:credo, "~>  0.9.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:poison, "~> 3.1", only: [:dev, :test]},
       {:exth_crypto, "~> 0.1.4"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,11 @@
-%{"binary": {:hex, :binary, "0.0.4", "dd077db70c0ded3e85c132b802338e14b80694684a7e2277666bfa4004b7fa66", [], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "exth_crypto": {:hex, :exth_crypto, "0.1.4", "11f9084dfd70d4f9e96f2710a472f4e6b23044b97530c719550c2b0450ffeb61", [], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.3", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
-  "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [], [], "hexpm"},
-  "libsecp256k1": {:hex, :libsecp256k1, "0.1.3", "57468b986af7c9633527875f71c7ca08bf4150b07b38a60d5bd48fba299ff6c1", [], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}
+%{
+  "binary": {:hex, :binary, "0.0.4", "dd077db70c0ded3e85c132b802338e14b80694684a7e2277666bfa4004b7fa66", [:mix], [], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "exth_crypto": {:hex, :exth_crypto, "0.1.4", "11f9084dfd70d4f9e96f2710a472f4e6b23044b97530c719550c2b0450ffeb61", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.3", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
+  "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.3", "57468b986af7c9633527875f71c7ca08bf4150b07b38a60d5bd48fba299ff6c1", [:rebar3], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -5,9 +5,9 @@
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.3", "774306f84973fc3f1e2e8743eeaa5f5d29b117f3916e5de74c075c02f1b8ef55", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "exth_crypto": {:hex, :exth_crypto, "0.1.5", "60f601d7c25032e7e4263fb1f42f17fed221ca0cdee7fbefad76f7624494e69b", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.7", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
+  "exth_crypto": {:hex, :exth_crypto, "0.1.6", "8e636a9bcb75d8e32451be96e547a495121ed2178d078db294edb0f81f7cf2e8", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.9", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
-  "libsecp256k1": {:hex, :libsecp256k1, "0.1.7", "25fc95202637c2544883f5ffe79eb905d63297bc270c2ab66b8964947dd8fe38", [:make, :mix], [{:mix_erlang_tasks, "0.1.0", [hex: :mix_erlang_tasks, repo: "hexpm", optional: false]}], "hexpm"},
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.9", "e725f31364cda7b554d56ce2bb976241303dde5ffd1ad59598513297bf1f2af6", [:make, :mix], [{:mix_erlang_tasks, "0.1.0", [hex: :mix_erlang_tasks, repo: "hexpm", optional: false]}], "hexpm"},
   "mix_erlang_tasks": {:hex, :mix_erlang_tasks, "0.1.0", "36819fec60b80689eb1380938675af215565a89320a9e29c72c70d97512e4649", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "binary": {:hex, :binary, "0.0.4", "dd077db70c0ded3e85c132b802338e14b80694684a7e2277666bfa4004b7fa66", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.3", "774306f84973fc3f1e2e8743eeaa5f5d29b117f3916e5de74c075c02f1b8ef55", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "exth_crypto": {:hex, :exth_crypto, "0.1.4", "11f9084dfd70d4f9e96f2710a472f4e6b23044b97530c719550c2b0450ffeb61", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.3", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,12 +1,13 @@
 %{
-  "binary": {:hex, :binary, "0.0.4", "dd077db70c0ded3e85c132b802338e14b80694684a7e2277666bfa4004b7fa66", [:mix], [], "hexpm"},
+  "binary": {:hex, :binary, "0.0.5", "20d816f7274ea34f1b673b4cff2fdb9ebec9391a7a68c349070d515c66b1b2cf", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.3", "774306f84973fc3f1e2e8743eeaa5f5d29b117f3916e5de74c075c02f1b8ef55", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "exth_crypto": {:hex, :exth_crypto, "0.1.4", "11f9084dfd70d4f9e96f2710a472f4e6b23044b97530c719550c2b0450ffeb61", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.3", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
+  "exth_crypto": {:hex, :exth_crypto, "0.1.5", "60f601d7c25032e7e4263fb1f42f17fed221ca0cdee7fbefad76f7624494e69b", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.7", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
-  "libsecp256k1": {:hex, :libsecp256k1, "0.1.3", "57468b986af7c9633527875f71c7ca08bf4150b07b38a60d5bd48fba299ff6c1", [:rebar3], [], "hexpm"},
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.7", "25fc95202637c2544883f5ffe79eb905d63297bc270c2ab66b8964947dd8fe38", [:make, :mix], [{:mix_erlang_tasks, "0.1.0", [hex: :mix_erlang_tasks, repo: "hexpm", optional: false]}], "hexpm"},
+  "mix_erlang_tasks": {:hex, :mix_erlang_tasks, "0.1.0", "36819fec60b80689eb1380938675af215565a89320a9e29c72c70d97512e4649", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/src/ethereum_abi_parser.yrl
+++ b/src/ethereum_abi_parser.yrl
@@ -61,8 +61,8 @@ plain_type(string) -> string;
 plain_type(bytes) -> bytes;
 plain_type(int) -> juxt_type(int, 256);
 plain_type(uint) -> juxt_type(uint, 256);
-plain_type(fixed) -> double_juxt_type(fixed, "x", 128, 19);
-plain_type(ufixed) -> double_juxt_type(ufixed, "x", 128, 19).
+plain_type(fixed) -> double_juxt_type(fixed, 'x', 128, 19);
+plain_type(ufixed) -> double_juxt_type(ufixed, 'x', 128, 19).
 
 with_subscripts(Type, []) -> Type;
 with_subscripts(Type, [H | T]) -> with_subscripts(with_subscript(Type, H), T).

--- a/test/abi/function_selector_test.exs
+++ b/test/abi/function_selector_test.exs
@@ -1,5 +1,4 @@
 defmodule ABI.FunctionSelectorTest do
   use ExUnit.Case, async: true
   doctest ABI.FunctionSelector
-
 end

--- a/test/abi/type_decoder_test.exs
+++ b/test/abi/type_decoder_test.exs
@@ -1,5 +1,4 @@
 defmodule ABI.TypeDecoderTest do
   use ExUnit.Case, async: true
   doctest ABI.TypeDecoder
-
 end

--- a/test/abi/type_encoder_test.exs
+++ b/test/abi/type_encoder_test.exs
@@ -1,5 +1,4 @@
 defmodule ABI.TypeEncoderTest do
   use ExUnit.Case, async: true
   doctest ABI.TypeEncoder
-
 end

--- a/test/abi_test.exs
+++ b/test/abi_test.exs
@@ -1,5 +1,4 @@
 defmodule ABITest do
   use ExUnit.Case
   doctest ABI
-
 end


### PR DESCRIPTION
This patch takes up from @atoulme's patch, adding a bump to exth_crypto which uses the newer version of libsecp256k1. Currently, getting the following issue on build:

```bash
mix test
make: Nothing to be done for `all'.
==> libsecp256k1
Compiling 1 file (.erl)
src/libsecp256k1.erl:146: Warning: function not_loaded/1 is unused
==> abi
Unchecked dependencies for environment test:
* libsecp256k1 (Hex package)
  could not find an app file at "_build/test/lib/libsecp256k1/ebin/libsecp256k1.app". This may happen if the dependency was not yet compiled, or you specified the wrong application name in your deps, or the dependency indeed has no app file (then you can pass app: false as option)
** (Mix) Can't continue due to errors on dependencies
```