### PR TITLE
Properly Treat All Function Encodings as Tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.15
+* Properly treat all function encodes as tuple encodings
 # 0.1.14
 * Fix 0-length `type[]` encoding
 # 0.1.13

--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -59,10 +59,10 @@ defmodule ABI do
       [50, <<1::160>>]
 
       iex> ABI.decode("(address[])", "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000" |> Base.decode16!(case: :lower))
-      [{[]}]
+      [[]]
 
       iex> ABI.decode("(string)", "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b457468657220546f6b656e000000000000000000000000000000000000000000" |> Base.decode16!(case: :lower))
-      [{"Ether Token"}]
+      ["Ether Token"]
 
       iex> File.read!("priv/dog.abi.json")
       ...> |> Jason.decode!
@@ -72,11 +72,12 @@ defmodule ABI do
       [<<1::160>>, true]
   """
   def decode(function_signature, data) when is_binary(function_signature) do
-    decode(ABI.Parser.parse!(function_signature), data)
+    decode(ABI.FunctionSelector.decode(function_signature), data)
   end
 
   def decode(%ABI.FunctionSelector{} = function_selector, data) do
-    ABI.TypeDecoder.decode(data, function_selector)
+    [res] = ABI.TypeDecoder.decode_raw(data, [{:tuple, function_selector.types}])
+    Tuple.to_list(res)
   end
 
   @doc """
@@ -121,7 +122,7 @@ defmodule ABI do
       []
 
       iex> ABI.decode("(string)", "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000643132333435363738393031323334353637383930313233343536373839303132333435363738393031323334353637383930313233343536373839303132333435363738393031323334353637383930313233343536373839303132333435363738393000000000000000000000000000000000000000000000000000000000" |> Base.decode16!(case: :lower))
-      [{String.duplicate("1234567890", 10)}]
+      [String.duplicate("1234567890", 10)]
 
       iex> [%{
       ...>   "payable" => false,

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -38,6 +38,15 @@ defmodule ABI.FunctionSelector do
         ]
       }
 
+      iex> ABI.FunctionSelector.decode("(uint256,bool)")
+      %ABI.FunctionSelector{
+        function: nil,
+        types: [
+          {:uint, 256},
+          :bool
+        ]
+      }
+
       iex> ABI.FunctionSelector.decode("growl(uint,address,string[])")
       %ABI.FunctionSelector{
         function: "growl",

--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -267,7 +267,7 @@ defmodule ABI.TypeDecoder do
 
   @spec decode_int(binary(), integer()) :: {integer(), binary()}
   defp decode_int(data, size_in_bits) do
-    total_bit_size = size_in_bits + ExthCrypto.Math.mod(256 - size_in_bits, 256)
+    total_bit_size = size_in_bits + ABI.Math.mod(256 - size_in_bits, 256)
     <<value::integer-signed-big-size(total_bit_size), rest::binary>> = data
 
     {value, rest}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "0.1.14",
+      version: "0.1.15",
       elixir: "~> 1.7",
       description: "Ethereum's ABI Interface",
       package: [


### PR DESCRIPTION
In Ethereum's ABI encoding spec, all function calls are treated as tuple encodings. This was being inconsistently done in our interface, leading to errors encoding dynamic types. This patch fixes the issue and allows dynamic typing to encode correctly.