### PR TITLE
Add Indexed to Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-alpha3"}
+    {:abi, "~> 1.0.0-alpha4"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-alpha3",
+      version: "1.0.0-alpha4",
       elixir: "~> 1.14",
       description: "Ethereum's ABI Interface",
       package: [


### PR DESCRIPTION
This patch reads "indexed" for events, which is useful information in decoding events.

Bump to 1.0.0-alpha4