### PR TITLE
Bugfix for is_dynamic Bump to 1.0.0-alpha6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.0.0-alpha6
+* Bugfix for is_dynamic
 # 0.1.15
 * Properly treat all function encodes as tuple encodings
 # 0.1.14

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-alpha5"}
+    {:abi, "~> 1.0.0-alpha6"}
   ]
 end
 ```

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -413,6 +413,7 @@ defmodule ABI.FunctionSelector do
   def is_dynamic?({:array, type, len}) when len > 0, do: is_dynamic?(type)
   def is_dynamic?({:tuple, types}), do: Enum.any?(types, fn arg_type -> is_dynamic?(arg_type.type) end)
   def is_dynamic?({:bytes,_}), do: false
+  def is_dynamic?({:int,_}), do: false
   def is_dynamic?({:uint,_}), do: false
   def is_dynamic?(:bool), do: false
   def is_dynamic?(:address), do: false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-alpha5",
+      version: "1.0.0-alpha6",
       elixir: "~> 1.14",
       description: "Ethereum's ABI Interface",
       package: [


### PR DESCRIPTION
We were missing a case for signed ints