### PR TITLE
Fix Event Decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.0.0-alpha7
+* Bugfix for event decoding with dynamic parameters
 # 1.0.0-alpha6
 * Bugfix for is_dynamic
 # 0.1.15

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-alpha6"}
+    {:abi, "~> 1.0.0-alpha7"}
   ]
 end
 ```

--- a/lib/abi/event.ex
+++ b/lib/abi/event.ex
@@ -41,14 +41,16 @@ defmodule ABI.Event do
       end)
       |> Enum.into(%{})
 
-    non_indexed_data =
-      data
-      |> ABI.TypeDecoder.decode_raw(non_indexed_types)
+    [non_indexed_data] = ABI.TypeDecoder.decode_raw(data, [%{type: {:tuple, non_indexed_types}}])
+
+    non_indexed_data_map =
+      non_indexed_data
+      |> Tuple.to_list()
       |> Enum.zip(non_indexed_types)
       |> Enum.map(fn {res, %{name: name}} -> {name, res} end)
       |> Enum.into(%{})
 
-    {function_selector.function, Map.merge(indexed_data, non_indexed_data)}
+    {function_selector.function, Map.merge(indexed_data, non_indexed_data_map)}
   end
 
   @doc ~S"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-alpha6",
+      version: "1.0.0-alpha7",
       elixir: "~> 1.14",
       description: "Ethereum's ABI Interface",
       package: [


### PR DESCRIPTION
This patch adds a fix to event decoders where they previously didn't properly handle "dynamic" data (e.g. strings). We wrap everything in a normal tuple and decode from that for this fix.

Bump to 1.0.0-alpha7