### PR TITLE
Check Event Signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0-alpha8
+* Add Event Signature check to ABI.Event.decode_event
+* Change `decode_event` to return an {:ok, event_name, event_params} tuple.
+* Add ability to add `"indexed"` keyword to ABI canonicals
 # 1.0.0-alpha7
 * Bugfix for event decoding with dynamic parameters
 # 1.0.0-alpha6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-alpha7"}
+    {:abi, "~> 1.0.0-alpha8"}
   ]
 end
 ```

--- a/lib/abi/event.ex
+++ b/lib/abi/event.ex
@@ -4,13 +4,12 @@ defmodule ABI.Event do
 
   ## Examples
 
-      iex> "00000000000000000000000000000000000000000000000000000004a817c800"
-      ...> |> Base.decode16!(case: :lower)
-      ...> |> ABI.Event.decode_event(
+      iex> ABI.Event.decode_event(
+      ...>   ~h[0x00000000000000000000000000000000000000000000000000000004a817c800],
       ...>   [
-      ...>     "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef" |> Base.decode16!(case: :lower),
-      ...>     "000000000000000000000000b2b7c1795f19fbc28fda77a95e59edbb8b3709c8" |> Base.decode16!(case: :lower),
-      ...>     "0000000000000000000000007795126b3ae468f44c901287de98594198ce38ea" |> Base.decode16!(case: :lower)
+      ...>     ~h[0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef],
+      ...>     ~h[0x000000000000000000000000b2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+      ...>     ~h[0x0000000000000000000000007795126b3ae468f44c901287de98594198ce38ea]
       ...>   ],
       ...>   %ABI.FunctionSelector{
       ...>     function: "Transfer",
@@ -20,46 +19,128 @@ defmodule ABI.Event do
       ...>       %{type: {:uint, 256}, name: "amount"},
       ...>     ]
       ...>   })
-      {"Transfer",
-       %{
-         "amount" => 20_000_000_000,
-         "from" => <<252, 55, 141, 170, 149, 43, 167, 241, 99, 196, 161, 22, 40, 245, 90, 77, 245, 35, 179, 239>>,
-         "to" => <<178, 183, 193, 121, 95, 25, 251, 194, 143, 218, 119, 169, 94, 89, 237, 187, 139, 55, 9, 200>>
-       }}
+      {:ok,
+        "Transfer", %{
+          "amount" => 20000000000,
+          "from" => ~h[0xb2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+          "to" => ~h[0x7795126b3ae468f44c901287de98594198ce38ea]
+      }}
+
+      iex> ABI.Event.decode_event(
+      ...>   ~h[0x00000000000000000000000000000000000000000000000000000004a817c800],
+      ...>   [
+      ...>     ~h[0x0000000000000000000000000000000000000000000000000000000000000001],
+      ...>     ~h[0x000000000000000000000000b2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+      ...>     ~h[0x0000000000000000000000007795126b3ae468f44c901287de98594198ce38ea]
+      ...>   ],
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   })
+      {:error, "Mismatched event signature topic[0], expected=DDF252AD1BE2C89B69C2B068FC378DAA952BA7F163C4A11628F55A4DF523B3EF, got=0000000000000000000000000000000000000000000000000000000000000001"}
+
+      iex> ABI.Event.decode_event(
+      ...>   ~h[0x00000000000000000000000000000000000000000000000000000004a817c800],
+      ...>   [
+      ...>     ~h[0x000000000000000000000000b2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+      ...>     ~h[0x0000000000000000000000007795126b3ae468f44c901287de98594198ce38ea]
+      ...>   ],
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   })
+      {:error, "Invalid topics length (got=2, expected=3), consider toggling `check_event_signature`"}
+
+      iex> ABI.Event.decode_event(
+      ...>   ~h[0x00000000000000000000000000000000000000000000000000000004a817c800],
+      ...>   [
+      ...>     ~h[0x000000000000000000000000b2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+      ...>     ~h[0x0000000000000000000000007795126b3ae468f44c901287de98594198ce38ea]
+      ...>   ],
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   },
+      ...>   check_event_signature: false
+      ...> )
+      {:ok,
+        "Transfer", %{
+          "amount" => 20000000000,
+          "from" => ~h[0xb2b7c1795f19fbc28fda77a95e59edbb8b3709c8],
+          "to" => ~h[0x7795126b3ae468f44c901287de98594198ce38ea]
+      }}
   """
-  def decode_event(data, topics, function_selector) do
+  def decode_event(data, topics, function_selector, opts \\ []) do
+    check_event_signature = Keyword.get(opts, :check_event_signature, true)
+
     # First, split the types into indexed and not indexed
     {indexed_types, non_indexed_types} =
       Enum.split_with(function_selector.types, fn t -> Map.get(t, :indexed) end)
 
-    indexed_data =
+    indexed_types_full = if check_event_signature do
+      [%{type: {:bytes, 32}, name: "__abi__topic"} | indexed_types]
+    else
       indexed_types
-      |> Enum.zip(topics)
-      |> Enum.map(fn {type, topic} ->
-        [value] = ABI.TypeDecoder.decode_raw(topic, [type])
-        {type.name, value}
-      end)
-      |> Enum.into(%{})
+    end
 
-    [non_indexed_data] = ABI.TypeDecoder.decode_raw(data, [%{type: {:tuple, non_indexed_types}}])
+    if Enum.count(indexed_types_full) != Enum.count(topics) do
+      {:error, "Invalid topics length (got=#{Enum.count(topics)}, expected=#{Enum.count(indexed_types_full)}), consider toggling `check_event_signature`"}
+    else
+      indexed_data =
+        indexed_types_full
+        |> Enum.zip(topics)
+        |> Enum.map(fn {type, topic} ->
+          [value] = ABI.TypeDecoder.decode_raw(topic, [type])
+          {type.name, value}
+        end)
+        |> Enum.into(%{})
 
-    non_indexed_data_map =
-      non_indexed_data
-      |> Tuple.to_list()
-      |> Enum.zip(non_indexed_types)
-      |> Enum.map(fn {res, %{name: name}} -> {name, res} end)
-      |> Enum.into(%{})
+      [non_indexed_data] = ABI.TypeDecoder.decode_raw(data, [%{type: {:tuple, non_indexed_types}}])
 
-    {function_selector.function, Map.merge(indexed_data, non_indexed_data_map)}
+      non_indexed_data_map =
+        non_indexed_data
+        |> Tuple.to_list()
+        |> Enum.zip(non_indexed_types)
+        |> Enum.map(fn {res, %{name: name}} -> {name, res} end)
+        |> Enum.into(%{})
+
+      indexed_data_res = if check_event_signature do
+        {event_signature, res} = Map.pop(indexed_data, "__abi__topic")
+
+        if event_signature == event_signature(function_selector) do
+          {:ok, res}
+        else
+          {:error, "Mismatched event signature topic[0], expected=#{Base.encode16(event_signature(function_selector))}, got=#{Base.encode16(event_signature)}"}
+        end
+      else
+        {:ok, indexed_data}
+      end
+
+      with {:ok, indexed_data_full} <- indexed_data_res do
+        {:ok, function_selector.function, Map.merge(indexed_data_full, non_indexed_data_map)}
+      end
+    end
   end
 
   @doc ~S"""
-  Returns the topic of an event, i.e. the first item that appears
+  Returns the signature of an event, i.e. the first item that appears
   in an Ethereum log for this event.
 
   ## Examples
 
-      iex> ABI.Event.event_topic(
+      iex> ABI.Event.event_signature(
       ...>   %ABI.FunctionSelector{
       ...>     function: "Transfer",
       ...>     types: [
@@ -69,12 +150,49 @@ defmodule ABI.Event do
       ...>     ]
       ...>   }
       ...> )
-      ...> |> Base.encode16(case: :lower)
-      "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+      ...> |> to_hex()
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
   """
-  def event_topic(function_selector) do
+  def event_signature(function_selector) do
     function_selector
     |> ABI.FunctionSelector.encode()
     |> ABI.Math.kec()
+  end
+
+  @doc ~S"""
+  Returns the canonical form of this event topic. Pass in `indexed: true`
+  to include "indexed" keywords.
+
+  ## Examples
+
+      iex> ABI.Event.canonical(
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   }
+      ...> )
+      "Transfer(address,address,uint256)"
+
+      iex> ABI.Event.canonical(
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   },
+      ...>   indexed: true
+      ...> )
+      "Transfer(address indexed,address indexed,uint256)"
+  """
+  def canonical(function_selector, opts \\ []) do
+    indexed = Keyword.get(opts, :indexed, false)
+
+    ABI.FunctionSelector.encode(function_selector, indexed)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,9 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-alpha7",
+      version: "1.0.0-alpha8",
       elixir: "~> 1.14",
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: "Ethereum's ABI Interface",
       package: [
         maintainers: ["Geoffrey Hayes", "Mason Fischer"],
@@ -24,6 +25,10 @@ defmodule ABI.Mixfile do
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/abi/event_test.exs
+++ b/test/abi/event_test.exs
@@ -1,4 +1,5 @@
 defmodule ABI.EventTest do
   use ExUnit.Case, async: true
+  use ABI.Hex
   doctest ABI.Event
 end

--- a/test/abi_test.exs
+++ b/test/abi_test.exs
@@ -1,4 +1,5 @@
 defmodule ABITest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+  use ABI.Hex
   doctest ABI
 end

--- a/test/support/hex.ex
+++ b/test/support/hex.ex
@@ -1,0 +1,371 @@
+defmodule ABI.Hex do
+  @moduledoc """
+  This is Signet.Hex, but copied just for test-cases.
+  """
+
+  defmodule HexError do
+    defexception message: "invalid hex"
+  end
+
+  @type t :: binary()
+
+  defmacro __using__(_opts) do
+    quote do
+      require ABI.Hex
+      alias ABI.Hex
+
+      import ABI.Hex,
+        only: [sigil_h: 2, hex!: 1, to_hex: 1, from_hex: 1, from_hex!: 1]
+    end
+  end
+
+  @doc ~S"""
+  Handles the sigil `~h` for list of words.
+
+  Parses a hex string at compile-time.
+
+  ## Examples
+
+      iex> use ABI.Hex
+      iex> ~h[0x22]
+      <<0x22>>
+
+      iex> use ABI.Hex
+      iex> ~h[0x2244]
+      <<0x22, 0x44>>
+  """
+  defmacro sigil_h(term, modifiers)
+
+  defmacro sigil_h({:<<>>, _meta, [string]}, _modifiers = []) when is_binary(string) do
+    hex_str = :elixir_interpolation.unescape_string(string)
+
+    ABI.Hex.decode_hex!(hex_str)
+  end
+
+  @doc ~S"""
+  Similar non-sigil compile-time hex parser.
+
+  ## Examples
+
+      iex> use ABI.Hex
+      iex> hex!("0x22")
+      <<0x22>>
+
+      iex> use ABI.Hex
+      iex> hex!("0x2244")
+      <<0x22, 0x44>>
+  """
+  defmacro hex!(hex_str) when is_binary(hex_str) do
+    ABI.Hex.decode_hex!(hex_str)
+  end
+
+  @doc """
+  Parses a hex string, but returns `:error` instead
+  of raising if hex is invalid.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_hex("0xaabb")
+    {:ok, <<170, 187>>}
+
+    iex> ABI.Hex.decode_hex("aabb")
+    {:ok, <<170, 187>>}
+
+    iex> ABI.Hex.decode_hex("0xgggg")
+    :invalid_hex
+  """
+  @spec decode_hex(String.t()) :: {:ok, t()} | :error
+  def decode_hex(b), do: decode_hex_(b)
+
+  @doc """
+  Alias for `decode_hex`.
+
+  ## Examples
+
+    iex> ABI.Hex.from_hex("0xaabb")
+    {:ok, <<0xaa, 0xbb>>}
+  """
+  @spec from_hex(t()) :: String.t()
+  def from_hex(b), do: decode_hex(b)
+
+  @doc """
+  Alias for `decode_hex!`.
+
+  ## Examples
+
+    iex> ABI.Hex.from_hex!("0xaabb")
+    <<0xaa, 0xbb>>
+  """
+  @spec from_hex!(t()) :: String.t()
+  def from_hex!(b), do: decode_hex!(b)
+
+  @doc """
+  Parses a hex string and raises if invalid.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_hex!("aabb")
+    <<170, 187>>
+
+    iex> ABI.Hex.decode_hex!("0xggaabb")
+    ** (ABI.Hex.HexError) invalid hex: "0xggaabb"
+  """
+  @spec decode_hex!(String.t()) :: t()
+  def decode_hex!(b) do
+    case decode_hex_(b) do
+      {:ok, hex} ->
+        hex
+
+      _ ->
+        raise HexError, "invalid hex: \"#{b}\""
+    end
+  end
+
+  @doc """
+  Parses an Ethereum 20-bytes hex string.
+
+  Identical to `decode_hex!/1` except fails if
+  string is not exactly 20-bytes.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_address!("0x0000000000000000000000000000000000000001")
+    <<1::160>>
+
+    iex> ABI.Hex.decode_address!("0xaabb")
+    ** (ABI.Hex.HexError) invalid hex address: "0xaabb"
+  """
+  @spec decode_address!(String.t()) :: t() | no_return()
+  def decode_address!(hex) do
+    decode_sized!(hex, 20, "invalid hex address")
+  end
+
+  @doc """
+  Parses an Ethereum 32-bytes hex string.
+
+  Identical to `decode_hex!/1` except fails if
+  string is not exactly 32-bytes.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_word!("0x0000000000000000000000000000000000000000000000000000000000000001")
+    <<1::256>>
+
+    iex> ABI.Hex.decode_word!("0xaabb")
+    ** (ABI.Hex.HexError) invalid hex word: "0xaabb"
+  """
+  @spec decode_word!(String.t()) :: t() | no_return()
+  def decode_word!(hex) do
+    decode_sized!(hex, 32, "invalid hex word")
+  end
+
+  @doc """
+  Parses an Ethereum x-bytes hex string.
+
+  Identical to `decode_hex!/1` except fails if
+  string is not exactly x-bytes.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_sized!("0x001122", 3)
+    <<0x00, 0x11, 0x22>>
+
+    iex> ABI.Hex.decode_sized!("0xaabb", 3)
+    ** (ABI.Hex.HexError) invalid 3-byte sized hex: "0xaabb"
+  """
+  @spec decode_sized!(String.t(), integer(), String.t() | nil) :: t() | no_return()
+  def decode_sized!(hex, sz, msg \\ nil) do
+    res = decode_hex!(hex)
+
+    if byte_size(res) == sz do
+      res
+    else
+      raise HexError,
+            (case msg do
+               nil ->
+                 "invalid #{sz}-byte sized hex: \"#{hex}\""
+
+               _ ->
+                 "#{msg}: \"#{hex}\""
+             end)
+    end
+  end
+
+  @doc """
+  Parses hex is value is not nil, otherwise returns `nil`.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_maybe_hex!("0xaabb")
+    <<170, 187>>
+
+    iex> ABI.Hex.decode_maybe_hex!(nil)
+    nil
+  """
+  @spec decode_maybe_hex!(String.t() | nil) :: t() | nil
+  def decode_maybe_hex!(h) when is_nil(h), do: nil
+  def decode_maybe_hex!(h) when is_binary(h), do: decode_hex!(h)
+
+  @doc """
+  Parses hex value as a big-endian integer. Raises if invalid.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_hex_number!("0xaabb")
+    0xaabb
+
+    iex> ABI.Hex.decode_hex_number!("0xgggg")
+    ** (ABI.Hex.HexError) invalid hex number: "0xgggg"
+  """
+  @spec decode_hex_number!(String.t()) :: integer() | no_return()
+  def decode_hex_number!(b) do
+    case decode_hex_number(b) do
+      {:ok, x} ->
+        x
+
+      :invalid_hex ->
+        raise HexError, "invalid hex number: \"#{b}\""
+    end
+  end
+
+  @doc """
+  Parses hex value as a big-endian integer.
+
+  ## Examples
+
+    iex> ABI.Hex.decode_hex_number("0xaabb")
+    {:ok, 0xaabb}
+
+    iex> ABI.Hex.decode_hex_number("0xgggg")
+    :invalid_hex
+  """
+  @spec decode_hex_number(String.t()) :: {:ok, integer()} | :error
+  def decode_hex_number(b) do
+    with {:ok, x} <- decode_hex(b), do: {:ok, :binary.decode_unsigned(x)}
+  end
+
+  @doc """
+  Encodes a given value as a lowercase hex string, starting with `0x`.
+
+  ## Examples
+
+    iex> ABI.Hex.encode_hex(<<0xaa, 0xbb>>)
+    "0xaabb"
+  """
+  @spec encode_hex(t()) :: String.t()
+  def encode_hex(b) when is_binary(b), do: "0x" <> Base.encode16(b, case: :lower)
+
+  @doc """
+  Alias for `encode_hex`.
+
+  ## Examples
+
+    iex> ABI.Hex.to_hex(<<0xaa, 0xbb>>)
+    "0xaabb"
+  """
+  @spec to_hex(t()) :: String.t()
+  def to_hex(b), do: encode_hex(b)
+
+  @doc ~S"""
+  Encodes hex, in CAPITALS.
+
+  ## Examples
+
+    iex> ABI.Hex.encode_big_hex(<<0xcc, 0xdd>>)
+    "0xCCDD"
+  """
+  @spec encode_big_hex(binary()) :: String.t()
+  def encode_big_hex(hex) when is_binary(hex), do: "0x" <> Base.encode16(hex)
+
+  @doc ~S"""
+  Encodes hex, striping any leading zeros.
+
+  ## Examples
+
+    iex> ABI.Hex.encode_short_hex(<<0xc>>)
+    "0xC"
+
+    iex> ABI.Hex.encode_short_hex(12)
+    "0xC"
+
+    iex> ABI.Hex.encode_short_hex(<<0x0>>)
+    "0x0"
+  """
+  @spec encode_short_hex(binary() | integer()) :: String.t()
+  def encode_short_hex(hex) when is_binary(hex) do
+    enc = Base.encode16(hex)
+
+    "0x" <>
+      case String.replace_leading(enc, "0", "") do
+        "" ->
+          "0"
+
+        els ->
+          els
+      end
+  end
+
+  def encode_short_hex(v) when is_integer(v), do: encode_short_hex(:binary.encode_unsigned(v))
+
+  @doc """
+  If input is a tuple `{:ok, x}` then returns a tuple `{:ok, hex}`
+  where `hex = encode(x)`. Otherwise, returns its input unchanged.
+
+  ## Examples
+
+    iex> ABI.Hex.encode_hex_result({:ok, <<0xaa, 0xbb>>})
+    {:ok, "0xaabb"}
+
+    iex> ABI.Hex.encode_hex_result({:error, 55})
+    {:error, 55}
+  """
+  @spec encode_hex_result({:ok, t()} | term()) :: {:ok, String.t()} | term()
+  def encode_hex_result({:ok, b}) when is_binary(b), do: {:ok, encode_hex(b)}
+  def encode_hex_result(els), do: els
+
+  @doc """
+  If input is non-`nil`, returns input encoded as a hex string. Otherwise,
+  returns `nil`.
+
+  ## Examples
+
+    iex> ABI.Hex.maybe_encode_hex(<<0xaa, 0xbb>>)
+    "0xaabb"
+
+    iex> ABI.Hex.maybe_encode_hex(nil)
+    nil
+  """
+  @spec maybe_encode_hex(t() | nil) :: String.t() | nil
+  def maybe_encode_hex(b) when is_nil(b), do: nil
+  def maybe_encode_hex(b) when is_binary(b), do: encode_hex(b)
+
+  # Core function to decode hex
+  @spec decode_hex_(String.t()) :: {:ok, t()} | :error
+  defp decode_hex_("0x" <> b) when is_binary(b), do: decode_hex_(b)
+
+  defp decode_hex_(b) when is_binary(b) do
+    hex_padded =
+      if rem(byte_size(b), 2) == 1 do
+        "0" <> b
+      else
+        b
+      end
+
+    case Base.decode16(hex_padded, case: :mixed) do
+      res = {:ok, _} ->
+        res
+
+      :error ->
+        :invalid_hex
+    end
+  end
+
+  @doc false
+  def deep_encode_binaries(x) when is_binary(x), do: to_hex(x)
+  def deep_encode_binaries(l) when is_list(l), do: Enum.map(l, &deep_encode_binaries/1)
+
+  def deep_encode_binaries(t) when is_tuple(t),
+    do: List.to_tuple(Enum.map(Tuple.to_list(t), &deep_encode_binaries/1))
+
+  def deep_encode_binaries(els), do: els
+end


### PR DESCRIPTION
This patch upgrades (breaking change) ABI to check event signature when decoding events. It also changes the function signature to return {:ok, "topic", params}, instead of raising on errors. Finally, you can return to older behavior via `check_event_signature: false`. We also rename `event_topic` to `event_signature` to be more accurate. And we add a function `ABI.Event.canonical` that returns the canonical event, with or without `"indexed"` keywords based on an `indexed: true/false` option.

Bump to 1.0.0-alpha8