### PR TITLE
Add Event Siganture Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.0.0-alpha9
+* Add Names to Event Signatures
 # 1.0.0-alpha8
 * Add Event Signature check to ABI.Event.decode_event
 * Change `decode_event` to return an {:ok, event_name, event_params} tuple.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-alpha8"}
+    {:abi, "~> 1.0.0-alpha9"}
   ]
 end
 ```

--- a/lib/abi/event.ex
+++ b/lib/abi/event.ex
@@ -186,13 +186,41 @@ defmodule ABI.Event do
       ...>       %{type: {:uint, 256}, name: "amount"},
       ...>     ]
       ...>   },
+      ...>   names: true
+      ...> )
+      "Transfer(address from,address to,uint256 amount)"
+
+      iex> ABI.Event.canonical(
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   },
       ...>   indexed: true
       ...> )
       "Transfer(address indexed,address indexed,uint256)"
+
+      iex> ABI.Event.canonical(
+      ...>   %ABI.FunctionSelector{
+      ...>     function: "Transfer",
+      ...>     types: [
+      ...>       %{type: :address, name: "from", indexed: true},
+      ...>       %{type: :address, name: "to", indexed: true},
+      ...>       %{type: {:uint, 256}, name: "amount"},
+      ...>     ]
+      ...>   },
+      ...>   indexed: true,
+      ...>   names: true
+      ...> )
+      "Transfer(address indexed from,address indexed to,uint256 amount)"
   """
   def canonical(function_selector, opts \\ []) do
     indexed = Keyword.get(opts, :indexed, false)
+    names = Keyword.get(opts, :names, false)
 
-    ABI.FunctionSelector.encode(function_selector, indexed)
+    ABI.FunctionSelector.encode(function_selector, indexed, names)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-alpha8",
+      version: "1.0.0-alpha9",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Ethereum's ABI Interface",


### PR DESCRIPTION
This patch adds the ability to add names to event signatures, e.g. `Transfer(address indexed from,address indexed to,uint256 amount)`.

Bump to 1.0.0-alpha9