### PR TITLE
Encode Structs [1.1.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-bravo6"}
+    {:abi, "~> 1.1.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.0.0-bravo1"}
+    {:abi, "~> 1.0.0-bravo6"}
   ]
 end
 ```

--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -100,9 +100,13 @@ defmodule ABI do
     decode(ABI.FunctionSelector.decode(function_signature), data)
   end
 
-  def decode(%ABI.FunctionSelector{} = function_selector, data) do
-    [res] = ABI.TypeDecoder.decode_raw(data, [%{type: {:tuple, function_selector.types}}])
-    Tuple.to_list(res)
+  def decode(%ABI.FunctionSelector{} = function_selector, data, opts \\ []) do
+    [res] = ABI.TypeDecoder.decode_raw(data, [%{type: {:tuple, function_selector.types}}], opts)
+    if is_tuple(res) do
+      Tuple.to_list(res)
+    else
+      res
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-bravo1",
+      version: "1.0.0-bravo6",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Ethereum's ABI Interface",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.0.0-bravo6",
+      version: "1.1.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Ethereum's ABI Interface",


### PR DESCRIPTION
This patch adds a simple mechanism to encode structs in ABI. This should allow you to basically use the struct keys names for encoding, if given as a map.

We also decode maps, if possible.

Bump to 1.1.0