### PR TITLE
feat: type encoder should support string keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `abi` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:abi, "~> 1.2.0"}
+    {:abi, "~> 1.3.0"}
   ]
 end
 ```

--- a/lib/abi/type_encoder.ex
+++ b/lib/abi/type_encoder.ex
@@ -432,10 +432,16 @@ defmodule ABI.TypeEncoder do
     Enum.map(types, fn type ->
       if type[:name] do
         atom_name = String.to_atom(Macro.underscore(type[:name]))
-        if data[atom_name] do
-          data[atom_name]
-        else
-          raise "Cannot find key `#{atom_name}` for type `#{inspect(type)}`\n\n\tin data:\n\n\t#{inspect(data)}"
+
+        cond do
+          Map.has_key?(data, type[:name]) ->
+            Map.fetch!(data, type[:name])
+
+          Map.has_key?(data, atom_name) ->
+            Map.fetch!(data, atom_name)
+
+          true ->
+            raise "Cannot find key `:#{atom_name}` or `\"#{type[:name]}\"` for type `#{inspect(type)}`\n\n\tin data:\n\n\t#{inspect(data)}"
         end
       else
         raise "Cannot decode struct with map when no name given in type `#{inspect(type)}`\n\n\tfor data:\n\n\t#{inspect(data)}"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ABI.Mixfile do
   def project do
     [
       app: :abi,
-      version: "1.2.0",
+      version: "1.3.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Ethereum's ABI Interface",


### PR DESCRIPTION
otherwise you cannot pass the decoded result of one call into the encoder for constructing the input for another call.

basically, since the decoder doesn't translate string keys into atom keys, the encoder should not expect inputs to always have symbol keys.

that way you can do:

```elixir
  call_a(ABI.encode(..., {...}))
  |> then(&call_b(ABI.encode(&1, ...)))
```

we run into this in Legend when we try to pass the results of one Sleuth query (the "network" query) into a query that depends on that result.

rather than tediously translate all the string keys we get out from the decoded result into symbol keys so that the encoder can _discard_ them and turn it into a tuple of the values, we should be allowed to just pass string-keyed maps into the encoder.