### PR TITLE
polish: Elixir 1.19 compat, typespec accuracy, and small fixes

### DIFF
--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -96,8 +96,11 @@ defmodule ABI do
       ...> |> Enum.find(&(&1.function == "bark")) # bark(address,bool)
       ...> |> ABI.decode("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16!(case: :lower))
       [<<1::160>>, true]
+
+      iex> ABI.decode("(uint256 a,bool b)", "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16!(case: :lower), decode_structs: true)
+      %{a: 10, b: true}
   """
-  @spec decode(binary() | ABI.FunctionSelector.t(), binary(), keyword()) :: [any()]
+  @spec decode(binary() | ABI.FunctionSelector.t(), binary(), keyword()) :: [any()] | map()
   def decode(function_signature, data, opts \\ [])
 
   def decode(function_signature, data, opts) when is_binary(function_signature) do
@@ -175,7 +178,7 @@ defmodule ABI do
       }}
   """
   @spec decode_event(binary() | ABI.FunctionSelector.t(), binary(), [binary()], keyword()) ::
-          {:ok, String.t(), map()} | {:error, term()}
+          {:ok, String.t() | nil, map()} | {:error, term()}
   def decode_event(function_signature, data, topics, opts \\ [])
 
   def decode_event(function_signature, data, topics, opts) when is_binary(function_signature) do

--- a/lib/abi.ex
+++ b/lib/abi.ex
@@ -55,6 +55,7 @@ defmodule ABI do
       ...> |> Base.encode16(case: :lower)
       "b85d0bd200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001"
   """
+  @spec encode(binary() | ABI.FunctionSelector.t(), [any()]) :: binary()
   def encode(function_signature, data) when is_binary(function_signature) do
     encode(ABI.Parser.parse!(function_signature), data)
   end
@@ -96,12 +97,16 @@ defmodule ABI do
       ...> |> ABI.decode("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16!(case: :lower))
       [<<1::160>>, true]
   """
-  def decode(function_signature, data) when is_binary(function_signature) do
-    decode(ABI.FunctionSelector.decode(function_signature), data)
+  @spec decode(binary() | ABI.FunctionSelector.t(), binary(), keyword()) :: [any()]
+  def decode(function_signature, data, opts \\ [])
+
+  def decode(function_signature, data, opts) when is_binary(function_signature) do
+    decode(ABI.FunctionSelector.decode(function_signature), data, opts)
   end
 
-  def decode(%ABI.FunctionSelector{} = function_selector, data, opts \\ []) do
+  def decode(%ABI.FunctionSelector{} = function_selector, data, opts) do
     [res] = ABI.TypeDecoder.decode_raw(data, [%{type: {:tuple, function_selector.types}}], opts)
+
     if is_tuple(res) do
       Tuple.to_list(res)
     else
@@ -169,6 +174,8 @@ defmodule ABI do
           "to" => ~h[0x7795126b3ae468f44c901287de98594198ce38ea]
       }}
   """
+  @spec decode_event(binary() | ABI.FunctionSelector.t(), binary(), [binary()], keyword()) ::
+          {:ok, String.t(), map()} | {:error, term()}
   def decode_event(function_signature, data, topics, opts \\ [])
 
   def decode_event(function_signature, data, topics, opts) when is_binary(function_signature) do

--- a/lib/abi/event.ex
+++ b/lib/abi/event.ex
@@ -1,4 +1,12 @@
 defmodule ABI.Event do
+  @moduledoc """
+  Decodes Ethereum event log data into Solidity-typed arguments.
+
+  Splits the topic list (indexed parameters) from the data blob (non-indexed
+  parameters) per the ABI specification, and optionally verifies that
+  `topics[0]` matches the `keccak256` hash of the event signature.
+  """
+
   @doc ~S"""
   Decodes an event, including handling parsing out data from topics.
 
@@ -119,17 +127,19 @@ defmodule ABI.Event do
         |> Enum.map(fn {res, %{name: name}} -> {name, res} end)
         |> Enum.into(%{})
 
-      indexed_data_res = if check_event_signature do
-        {event_signature, res} = Map.pop(indexed_data, "__abi__topic")
+      indexed_data_res =
+        if check_event_signature do
+          {event_signature, res} = Map.pop(indexed_data, "__abi__topic")
 
-        if event_signature == event_signature(function_selector) do
-          {:ok, res}
+          if event_signature == event_signature(function_selector) do
+            {:ok, res}
+          else
+            {:error,
+             "Mismatched event signature topic[0], expected=#{Base.encode16(event_signature(function_selector))}, got=#{Base.encode16(event_signature)}"}
+          end
         else
-          {:error, "Mismatched event signature topic[0], expected=#{Base.encode16(event_signature(function_selector))}, got=#{Base.encode16(event_signature)}"}
+          {:ok, indexed_data}
         end
-      else
-        {:ok, indexed_data}
-      end
 
       with {:ok, indexed_data_full} <- indexed_data_res do
         {:ok, function_selector.function, Map.merge(indexed_data_full, non_indexed_data_map)}

--- a/lib/abi/function_selector.ex
+++ b/lib/abi/function_selector.ex
@@ -4,8 +4,6 @@ defmodule ABI.FunctionSelector do
   `my_function(uint64, string[])`.
   """
 
-  require Integer
-
   @type type ::
           {:uint, integer()}
           | :bool
@@ -25,11 +23,11 @@ defmodule ABI.FunctionSelector do
   @type state_mutability :: :nonpayable | :pure | :view | :payable
 
   @type t :: %__MODULE__{
-          function: String.t(),
+          function: String.t() | nil,
           function_type: function_type() | nil,
           state_mutability: state_mutability() | nil,
-          types: [argument_type],
-          returns: type
+          types: [argument_type()],
+          returns: type() | [argument_type()] | nil
         }
 
   defstruct [:function, :function_type, :state_mutability, :types, :returns]
@@ -303,15 +301,15 @@ defmodule ABI.FunctionSelector do
     }
   end
 
-  defp parse_specification_type(record=%{"name" => name, "indexed" => indexed}) do
+  defp parse_specification_type(record = %{"name" => name, "indexed" => indexed}) do
     %{name: name, type: parse_specification_type_type(record), indexed: indexed}
   end
 
-  defp parse_specification_type(record=%{"indexed" => indexed}) do
+  defp parse_specification_type(record = %{"indexed" => indexed}) do
     %{type: parse_specification_type_type(record), indexed: indexed}
   end
 
-  defp parse_specification_type(record=%{"name" => name}) do
+  defp parse_specification_type(record = %{"name" => name}) do
     %{name: name, type: parse_specification_type_type(record)}
   end
 
@@ -422,7 +420,7 @@ defmodule ABI.FunctionSelector do
   end
 
   defp get_types(function_selector, indexed, names) do
-    for {t=%{type: type}, i} <- Enum.with_index(function_selector.types) do
+    for {t = %{type: type}, i} <- Enum.with_index(function_selector.types) do
       indexed_postfix = if indexed and Map.get(t, :indexed, false), do: " indexed", else: ""
       name_postfix = if names, do: " #{Map.get(t, :name, "var#{i}")}", else: ""
       "#{get_type(type)}#{indexed_postfix}#{name_postfix}"
@@ -463,10 +461,13 @@ defmodule ABI.FunctionSelector do
   def is_dynamic?(:string), do: true
   def is_dynamic?({:array, _type}), do: true
   def is_dynamic?({:array, type, len}) when len > 0, do: is_dynamic?(type)
-  def is_dynamic?({:tuple, types}), do: Enum.any?(types, fn arg_type -> is_dynamic?(arg_type.type) end)
-  def is_dynamic?({:bytes,_}), do: false
-  def is_dynamic?({:int,_}), do: false
-  def is_dynamic?({:uint,_}), do: false
+
+  def is_dynamic?({:tuple, types}),
+    do: Enum.any?(types, fn arg_type -> is_dynamic?(arg_type.type) end)
+
+  def is_dynamic?({:bytes, _}), do: false
+  def is_dynamic?({:int, _}), do: false
+  def is_dynamic?({:uint, _}), do: false
   def is_dynamic?(:bool), do: false
   def is_dynamic?(:address), do: false
 

--- a/lib/abi/type_decoder.ex
+++ b/lib/abi/type_decoder.ex
@@ -6,10 +6,6 @@ defmodule ABI.TypeDecoder do
   specification.
   """
 
-  @type decode_options :: %{
-    optional(:decode_structs) => boolean()
-  }
-
   @doc """
   Decodes the given data based on the function selector.
 
@@ -196,11 +192,12 @@ defmodule ABI.TypeDecoder do
       ...> |> ABI.TypeDecoder.decode_raw([%{type: {:tuple, [%{type: :string}, %{type: :bool}]}}])
       [{"awesome", true}]
   """
+  @spec decode_raw(binary(), [ABI.FunctionSelector.argument_type()], keyword()) :: [any()]
   def decode_raw(encoded_data, types, opts \\ []) do
     do_decode(types, encoded_data, [], opts)
   end
 
-  @spec do_decode([ABI.FunctionSelector.type()], binary(), [any()], decode_options()) :: [any()]
+  @spec do_decode([ABI.FunctionSelector.argument_type()], binary(), [any()], keyword()) :: [any()]
   defp do_decode([], bin, _, _opts) when byte_size(bin) > 0,
     do: raise("Found extra binary data: #{inspect(bin)}")
 
@@ -212,7 +209,7 @@ defmodule ABI.TypeDecoder do
     do_decode(remaining_types, remaining_data, [decoded | acc], opts)
   end
 
-  @spec decode_type(ABI.FunctionSelector.type(), binary(), decode_options()) :: {any(), binary()}
+  @spec decode_type(ABI.FunctionSelector.type(), binary(), keyword()) :: {any(), binary()}
   defp decode_type({:uint, size_in_bits}, data, _opts) do
     decode_uint(data, size_in_bits)
   end
@@ -306,7 +303,8 @@ defmodule ABI.TypeDecoder do
   end
 
   def tuple_value(types, elements, decode_structs) do
-    if decode_structs and Enum.all?(types, fn type -> type[:name] != nil and type[:name] != <<>> end) do
+    if decode_structs and
+         Enum.all?(types, fn type -> type[:name] != nil and type[:name] != <<>> end) do
       Enum.zip(types, elements)
       |> Enum.map(fn {type, element} ->
         {String.to_atom(Macro.underscore(type[:name])), element}
@@ -322,7 +320,7 @@ defmodule ABI.TypeDecoder do
     # TODO: Create `left_pad` repo, err, add to `ABI.Math`
     total_bit_size = size_in_bits + ABI.Math.mod(256 - size_in_bits, 256)
 
-    <<value::integer-size(total_bit_size), rest::binary>> = data
+    <<value::integer-size(^total_bit_size), rest::binary>> = data
 
     {value, rest}
   end
@@ -330,7 +328,7 @@ defmodule ABI.TypeDecoder do
   @spec decode_int(binary(), integer()) :: {integer(), binary()}
   defp decode_int(data, size_in_bits) do
     total_bit_size = size_in_bits + ABI.Math.mod(256 - size_in_bits, 256)
-    <<value::integer-signed-big-size(total_bit_size), rest::binary>> = data
+    <<value::integer-signed-big-size(^total_bit_size), rest::binary>> = data
 
     {value, rest}
   end
@@ -344,13 +342,13 @@ defmodule ABI.TypeDecoder do
 
     case padding_direction do
       :left ->
-        <<_padding::binary-size(padding_size_in_bytes), value::binary-size(size_in_bytes),
+        <<_padding::binary-size(^padding_size_in_bytes), value::binary-size(^size_in_bytes),
           rest::binary>> = data
 
         {value, rest}
 
       :right ->
-        <<value::binary-size(size_in_bytes), _padding::binary-size(padding_size_in_bytes),
+        <<value::binary-size(^size_in_bytes), _padding::binary-size(^padding_size_in_bytes),
           rest::binary>> = data
 
         {value, rest}

--- a/lib/abi/type_encoder.ex
+++ b/lib/abi/type_encoder.ex
@@ -201,15 +201,16 @@ defmodule ABI.TypeEncoder do
       ...> |> Base.encode16(case: :lower)
       "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01"
   """
+  @spec encode([any()], ABI.FunctionSelector.t()) :: binary()
   def encode(data, function_selector) do
     encode_method_id(function_selector) <> do_encode_data(data, function_selector)
   end
 
-  defp do_encode_data(data, %ABI.FunctionSelector{function: nil}=function_selector) do
+  defp do_encode_data(data, %ABI.FunctionSelector{function: nil} = function_selector) do
     encode_raw(data, function_selector.types)
   end
 
-  defp do_encode_data(data, %ABI.FunctionSelector{}=function_selector) do
+  defp do_encode_data(data, %ABI.FunctionSelector{} = function_selector) do
     encode_raw([List.to_tuple(data)], [%{type: {:tuple, function_selector.types}}])
   end
 
@@ -229,7 +230,7 @@ defmodule ABI.TypeEncoder do
     do_encode(types, data, [])
   end
 
-  @spec encode_method_id(%ABI.FunctionSelector{}) :: binary()
+  @spec encode_method_id(ABI.FunctionSelector.t()) :: binary()
   defp encode_method_id(%ABI.FunctionSelector{function: nil}), do: ""
 
   defp encode_method_id(function_selector) do
@@ -246,7 +247,7 @@ defmodule ABI.TypeEncoder do
     init
   end
 
-  @spec do_encode([ABI.FunctionSelector.type()], [any()], [binary()]) :: binary()
+  @spec do_encode([ABI.FunctionSelector.argument_type()], [any()], [binary()]) :: binary()
   defp do_encode([], _, acc), do: :erlang.iolist_to_binary(Enum.reverse(acc))
 
   defp do_encode([type | remaining_types], data, acc) do
@@ -306,8 +307,9 @@ defmodule ABI.TypeEncoder do
 
     {head, tail, [], _} =
       Enum.reduce(types, {<<>>, <<>>, data_to_list(types, data), tail_start}, fn argument_type,
-                                                                               {head, tail, data,
-                                                                                tail_position} ->
+                                                                                 {head, tail,
+                                                                                  data,
+                                                                                  tail_position} ->
         type = argument_type.type
         {el, rest} = encode_type(type, data)
 
@@ -325,11 +327,12 @@ defmodule ABI.TypeEncoder do
   end
 
   defp encode_type({:array, type, element_count}, [data | rest]) do
-    repeated_type = if element_count == 0 do
-      []
-    else
-       Enum.map(1..element_count, fn _ -> %{type: type} end)
-    end
+    repeated_type =
+      if element_count == 0 do
+        []
+      else
+        Enum.map(1..element_count, fn _ -> %{type: type} end)
+      end
 
     encode_type({:tuple, repeated_type}, [data |> List.to_tuple() | rest])
   end
@@ -351,7 +354,8 @@ defmodule ABI.TypeEncoder do
     bytes |> pad(byte_size(bytes), :right)
   end
 
-  defp encode_int(int, desired_size_bits) when rem(desired_size_bits, 8) == 0 and is_integer(int) do
+  defp encode_int(int, desired_size_bits)
+       when rem(desired_size_bits, 8) == 0 and is_integer(int) do
     desired_size_bytes = ceil(desired_size_bits / 8)
 
     sign_byte = if(int < 0, do: <<0xFF>>, else: <<0x00>>)
@@ -415,7 +419,7 @@ defmodule ABI.TypeEncoder do
     |> Enum.sum()
   end
 
-  defp do_count(%{type: t={:tuple, sub_types}}) do
+  defp do_count(%{type: t = {:tuple, sub_types}}) do
     if ABI.FunctionSelector.is_dynamic?(t) do
       1
     else
@@ -424,10 +428,12 @@ defmodule ABI.TypeEncoder do
       |> Enum.sum()
     end
   end
+
   defp do_count(_), do: 1
 
   defp data_to_list(_types, data) when is_list(data), do: data
   defp data_to_list(_types, data) when is_tuple(data), do: Tuple.to_list(data)
+
   defp data_to_list(types, data) when is_map(data) do
     Enum.map(types, fn type ->
       if type[:name] do

--- a/src/ethereum_abi_parser.yrl
+++ b/src/ethereum_abi_parser.yrl
@@ -1,6 +1,10 @@
-Terminals '(' ')' '[' ']' ',' '->' 'x' typename 'indexed' letters digits 'expecting identifier' 'expecting selector' 'expecting type'.
+Terminals '(' ')' '[' ']' ',' '->' 'x' typename 'indexed' letters digits 'expecting selector' 'expecting type'.
 Nonterminals dispatch selector nontrivial_selector comma_delimited_types type_with_subscripts type_index_name array_subscripts tuple array_subscript identifier  identifier_parts identifier_part type typespec.
 Rootsymbol dispatch.
+%% Expect 1 shift/reduce conflict: the `dispatch` rules allow both a bare
+%% `tuple` and a `nontrivial_selector` that begins with a `typespec` (which
+%% can also be a tuple), making this ambiguity structural rather than a bug.
+Expect 1.
 
 dispatch -> 'expecting type' type_with_subscripts : {type, '$2'}.
 dispatch -> 'expecting selector' selector : {selector, '$2'}.


### PR DESCRIPTION
Small polish pass on the library surface — five topics bundled as one PR. Happy to split if you'd prefer.

### 1. Fix `opts` silently dropped in `ABI.decode/3` with string signatures

The string-signature clause re-dispatched through `decode(selector, data)`, losing `opts`. Options like `decode_structs: true` never reached `TypeDecoder.decode_raw` unless the caller had already parsed the selector themselves:

```elixir
# Before: opts silently dropped
ABI.decode("foo((uint256,address))", data, decode_structs: true)

# After: opts flow through both arms
```

Standard header + default pattern; non-breaking for existing `decode/2` callers.

### 2. Elixir 1.19+ compat: pin variables in binary-pattern sizes

Elixir 1.19 deprecates unpinned variables in bitstring pattern sizes. `TypeDecoder` now uses `^var`:

```elixir
<<value::integer-size(^total_bit_size), rest::binary>> = data
```

Compiles clean on both 1.18 and 1.19.

### 3. Typespec accuracy

- `ABI.FunctionSelector.t.function` is `String.t() | nil` — raw-tuple selectors have `nil`.
- `ABI.FunctionSelector.t.returns` is `type() | [argument_type()] | nil` — the constructor sets it to a list, and `nil` is valid.
- `ABI.TypeDecoder` drops the unused `decode_options()` map typespec and switches specs to `keyword()`, matching the actual call convention (`decode_raw(data, types, opts \\ [])`).
- `@spec` added on public entry points: `ABI.encode/2`, `ABI.decode/3`, `ABI.decode_event/4`, `ABI.TypeDecoder.decode_raw/3`, `ABI.TypeEncoder.encode/2`.

### 4. Grammar cleanup in `src/ethereum_abi_parser.yrl`

- Drop unused `'expecting identifier'` terminal.
- Declare `Expect 1.` with a comment — the structural shift/reduce conflict between `dispatch` rules (a bare tuple vs. a selector starting with a typespec that is itself a tuple) is not a bug, and this silences the compile-time warning.

### 5. `@moduledoc` for `ABI.Event`

One paragraph summarising what the module does.

---

All 98 existing tests pass.